### PR TITLE
Use the correct object type values for MNTP (closes #25)

### DIFF
--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultiNodeTreePickerPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultiNodeTreePickerPropertyValueHandler.cs
@@ -22,8 +22,11 @@ internal sealed class MultiNodeTreePickerPropertyValueHandler : IPropertyValueHa
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         MultiNodePickerConfiguration? configuration = _dataTypeConfigurationCache.GetConfigurationAs<MultiNodePickerConfiguration>(property.PropertyType.DataTypeKey);
-        // NOTE: the default configuration for MNTP has ObjectType null, which is inferred as a document picker
-        if (configuration?.TreeSource?.ObjectType is not (null or Umbraco.Cms.Core.Constants.ObjectTypes.Strings.Document))
+
+        // NOTES:
+        // - the default configuration for MNTP has ObjectType null, which is inferred as a document picker
+        // - the DocumentObjectType is an internal constant in Umbraco 16 - value is "content"
+        if (configuration?.TreeSource?.ObjectType is not (null or "content"))
         {
             return [];
         }

--- a/src/Umbraco.Test.Search.Integration/Tests/MultiNodeTreePickerPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MultiNodeTreePickerPropertyValueHandlerTests.cs
@@ -137,7 +137,8 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
                     "startNode",
                     new MultiNodePickerConfigurationTreeSource
                     {
-                        ObjectType = Constants.ObjectTypes.Strings.Document
+                        // hardcoded object type here - see notes in MultiNodeTreePickerPropertyValueHandler
+                        ObjectType = "content"
                     }
                 }
             },
@@ -156,7 +157,8 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
                     "startNode",
                     new MultiNodePickerConfigurationTreeSource
                     {
-                        ObjectType = Constants.ObjectTypes.Strings.Media
+                        // hardcoded object type here - see notes in MultiNodeTreePickerPropertyValueHandler
+                        ObjectType = "media"
                     }
                 }
             },
@@ -175,7 +177,8 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
                     "startNode",
                     new MultiNodePickerConfigurationTreeSource
                     {
-                        ObjectType = Constants.ObjectTypes.Strings.Member
+                        // hardcoded object type here - see notes in MultiNodeTreePickerPropertyValueHandler
+                        ObjectType = "member"
                     }
                 }
             },


### PR DESCRIPTION
Supersedes https://github.com/umbraco/Umbraco.Cms.Search/pull/27

All credits go to @robertjf for finding the root cause 👍 