### PR TITLE
Dependency tracking

### DIFF
--- a/build/azure-pipeline.yml
+++ b/build/azure-pipeline.yml
@@ -235,6 +235,8 @@ stages:
     dependsOn:
       - Build
       - IntegrationTests
+    # Only upload the SBOM when it's from the main branch, as we don't need to for every PR.
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     jobs:
       - job: sbom
         displayName: Upload SBOM to DependencyTrack


### PR DESCRIPTION
# Notes
This implemens dependency tracking, by using the inbuilt task. 
Some considerations where made, I've discussed having a internal standard, and will bring it up at our weekly dev meeting monday, so this is subject to change: 

- Made non-optional, so will update for every PR made, as it's more important to track the current use of dependencies, to warn against vulnerabilites.
- Does not upload specific version, instead it just uploads as `main`, reason is mainly because of above, we upload per PR, and not per release.