### PR TITLE
WIP: Support for Examine v4 latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Examine" Version="4.0.0-beta.1" />
+    <PackageVersion Include="Examine" Version="4.0.0-beta.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NUnit" Version="3.14.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="localExamine" value="C:\Users\sdemi\Downloads\examine-nuget" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="localExamine">
+      <package pattern="Examine*" />
+    </packageSource>
+    <!-- Ensure all packages are pulled from NuGet -->
+    <packageSource key="nuget">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/src/Umbraco.Cms.Search.Provider.Examine/Compat/CompatConfigurationEnabledDirectoryFactory.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Compat/CompatConfigurationEnabledDirectoryFactory.cs
@@ -1,0 +1,60 @@
+using Examine;
+using Examine.Lucene.Directories;
+using Examine.Lucene.Providers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Infrastructure.Examine;
+using Directory = Lucene.Net.Store.Directory;
+
+namespace Umbraco.Cms.Search.Provider.Examine.Compat;
+
+internal sealed class CompatConfigurationEnabledDirectoryFactory : IDirectoryFactory
+{
+    private readonly IApplicationRoot _applicationRoot;
+    private readonly IServiceProvider _services;
+    private readonly IndexCreatorSettings _settings;
+    private IDirectoryFactory? _directoryFactory;
+
+    public CompatConfigurationEnabledDirectoryFactory(
+        IServiceProvider services,
+        IOptions<IndexCreatorSettings> settings,
+        IApplicationRoot applicationRoot)
+    {
+        _services = services;
+        _applicationRoot = applicationRoot;
+        _settings = settings.Value;
+    }
+
+    public Directory CreateTaxonomyDirectory(LuceneIndex luceneIndex, bool forceUnlock)
+    {
+        _directoryFactory ??= CreateFactory();
+        return _directoryFactory.CreateTaxonomyDirectory(luceneIndex, forceUnlock);
+    }
+
+    public Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock)
+    {
+        _directoryFactory ??= CreateFactory();
+        return _directoryFactory.CreateDirectory(luceneIndex, forceUnlock);
+    }
+
+    /// <summary>
+    ///     Creates a directory factory based on the configured value and ensures that
+    /// </summary>
+    private IDirectoryFactory CreateFactory()
+    {
+        DirectoryInfo dirInfo = _applicationRoot.ApplicationRoot;
+
+        if (!dirInfo.Exists)
+        {
+            System.IO.Directory.CreateDirectory(dirInfo.FullName);
+        }
+
+        return _settings.LuceneDirectoryFactory switch
+        {
+            LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory => _services.GetRequiredService<SyncedFileSystemDirectoryFactory>(),
+            LuceneDirectoryFactory.TempFileSystemDirectoryFactory => _services.GetRequiredService<UmbracoTempEnvFileSystemDirectoryFactory>(),
+            _ => _services.GetRequiredService<FileSystemDirectoryFactory>(),
+        };
+    }
+}

--- a/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Search.Provider.Examine.Compat;
 
 namespace Umbraco.Cms.Search.Provider.Examine.DependencyInjection;
 
@@ -13,13 +14,13 @@ public static class UmbracoBuilderExtensions
 {
     public static IUmbracoBuilder AddExamineSearchProvider(this IUmbracoBuilder builder)
     {
-        builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftContent, _ => { });
+        builder.Services.AddExamineLuceneIndex<LuceneIndex, CompatConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftContent, _ => { });
 
-        builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.PublishedContent, _ => { });
+        builder.Services.AddExamineLuceneIndex<LuceneIndex, CompatConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.PublishedContent, _ => { });
 
-        builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftMedia, _ => { });
+        builder.Services.AddExamineLuceneIndex<LuceneIndex, CompatConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftMedia, _ => { });
 
-        builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftMembers, _ => { });
+        builder.Services.AddExamineLuceneIndex<LuceneIndex, CompatConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftMembers, _ => { });
 
         // This is needed, due to locking of indexes on Azure, to read more on this issue go here: https://github.com/umbraco/Umbraco-CMS/pull/15571
         builder.Services.AddSingleton<UmbracoTempEnvFileSystemDirectoryFactory>();

--- a/src/Umbraco.Cms.Search.Provider.Examine/Umbraco.Cms.Search.Provider.Examine.csproj
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Umbraco.Cms.Search.Provider.Examine.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Umbraco.Cms.Search.Core\Umbraco.Cms.Search.Core.csproj"/>
+    <ProjectReference Include="..\Umbraco.Cms.Search.Core\Umbraco.Cms.Search.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Examine"/>
+    <PackageReference Include="Examine" />
     <PackageReference Include="Umbraco.Cms.Examine.Lucene" />
   </ItemGroup>
 

--- a/src/Umbraco.Cms.Search.sln
+++ b/src/Umbraco.Cms.Search.sln
@@ -22,14 +22,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.artifactignore = ..\.artifactignore
 		..\.editorconfig = ..\.editorconfig
 		..\.globalconfig = ..\.globalconfig
+		..\build\azure-pipeline.yml = ..\build\azure-pipeline.yml
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\Directory.Packages.props = ..\Directory.Packages.props
 		..\global.json = ..\global.json
 		..\LICENSE = ..\LICENSE
+		..\nuget.config = ..\nuget.config
 		..\README.md = ..\README.md
 		..\umbraco-marketplace.json = ..\umbraco-marketplace.json
 		..\version.json = ..\version.json
-		..\build\azure-pipeline.yml = ..\build\azure-pipeline.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/TestInMemoryDirectoryFactory.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/TestInMemoryDirectoryFactory.cs
@@ -1,22 +1,29 @@
-﻿using Examine.Lucene.Directories;
+using Examine.Lucene.Directories;
 using Examine.Lucene.Providers;
 using Directory = Lucene.Net.Store.Directory;
 
 namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.IndexService;
 
-public class TestInMemoryDirectoryFactory : DirectoryFactoryBase
+public class TestInMemoryDirectoryFactory : IDirectoryFactory
 {
-    private RandomIdRAMDirectory _randomIdRamDirectory = null!;
+    private RandomIdRAMDirectory? _mainDir;
+    private RandomIdRAMDirectory? _taxonomyDir;
 
-    protected override Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock)
+    public Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock)
     {
-        _randomIdRamDirectory = new RandomIdRAMDirectory();
-        return _randomIdRamDirectory;
+        _mainDir ??= new RandomIdRAMDirectory();
+        return _mainDir;
     }
 
-    protected override void Dispose(bool disposing)
+    public Directory CreateTaxonomyDirectory(LuceneIndex luceneIndex, bool forceUnlock)
     {
-        base.Dispose(disposing);
-        _randomIdRamDirectory.Dispose();
+        _taxonomyDir ??= new RandomIdRAMDirectory();
+        return _taxonomyDir;
+    }
+
+    public void Dispose()
+    {
+        _mainDir?.Dispose();
+        _taxonomyDir?.Dispose();
     }
 }


### PR DESCRIPTION
Init commit to support Examine v4 latest.

These tests pass but the rest don't:

<img width="398" height="331" alt="image" src="https://github.com/user-attachments/assets/6630d63c-89b1-4174-96a8-0df8d58eda80" />

That is because of the removal of the DirectoryFactoryBase which is being referenced by Umbraco under the hood via reference so it has type load exceptions.

So now we need to decide on compatibility. I've mentioned some of this here: https://github.com/umbraco/Umbraco-CMS/pull/21176

