### PR TITLE
Move required service registrations for DB caching to core

### DIFF
--- a/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -15,6 +15,7 @@ using Umbraco.Cms.Search.Core.Cache.Media;
 using Umbraco.Cms.Search.Core.Cache.PublicAccess;
 using Umbraco.Cms.Search.Core.Helpers;
 using Umbraco.Cms.Search.Core.NotificationHandlers;
+using Umbraco.Cms.Search.Core.Persistence;
 using Umbraco.Cms.Search.Core.PropertyValueHandlers;
 using Umbraco.Cms.Search.Core.PropertyValueHandlers.Collection;
 using Umbraco.Cms.Search.Core.Services;
@@ -44,6 +45,10 @@ public static class UmbracoBuilderExtensions
 
         builder.Services.AddTransient<IPublishedContentChangeStrategy, PublishedContentChangeStrategy>();
         builder.Services.AddTransient<IDraftContentChangeStrategy, DraftContentChangeStrategy>();
+
+        builder.Services.AddSingleton<IIndexDocumentRepository, IndexDocumentRepository>();
+        builder.Services.AddSingleton<IIndexDocumentService, IndexDocumentService>();
+
         builder
             .AddNotificationAsyncHandler<LanguageDeletedNotification, RebuildIndexesNotificationHandler>()
             .AddNotificationAsyncHandler<ContentTypeChangedNotification, RebuildIndexesNotificationHandler>()

--- a/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/ServiceCollectionExtensions.cs
@@ -20,8 +20,6 @@ internal static class ServiceCollectionExtensions
         // register the in-memory searcher and indexer so they can be used explicitly for index registrations
         services.AddTransient<IExamineIndexer, Indexer>();
         services.AddTransient<IExamineSearcher, Searcher>();
-        services.AddSingleton<IIndexDocumentRepository, IndexDocumentRepository>();
-        services.AddSingleton<IIndexDocumentService, IndexDocumentService>();
 
         services.AddTransient<IIndexer, Indexer>();
         services.AddTransient<ISearcher, Searcher>();

--- a/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
@@ -37,8 +37,7 @@ public abstract class TestBase : UmbracoIntegrationTest
         builder.Services.AddUnique<IBackgroundTaskQueue, ImmediateBackgroundTaskQueue>();
         builder.Services.AddUnique<IServerMessenger, LocalServerMessenger>();
         builder.Services.AddUnique<IServerEventRouter, NoOpServerEventRouter>();
-        builder.Services.AddUnique<IIndexDocumentService, IndexDocumentService>();
-        builder.Services.AddUnique<IIndexDocumentRepository, IndexDocumentRepository>();
+        builder.Services.AddUnique<IIndexDocumentRepository, NoopIndexDocumentRepository>();
 
         builder.Services.AddTransient<IIndexer>(_ => Indexer);
         builder.Services.AddTransient<ISearcher>(_ => Indexer);
@@ -57,13 +56,16 @@ public abstract class TestBase : UmbracoIntegrationTest
         builder.AddNotificationHandler<MemberDeletedNotification, MemberDeletedDistributedCacheNotificationHandler>();
     }
 
-    private class IndexDocumentRepository : IIndexDocumentRepository
+    // these tests are not concerned with DB cached index data, so this is a no-op implementation
+    // of the document repository.
+    private class NoopIndexDocumentRepository : IIndexDocumentRepository
     {
         public Task AddAsync(IndexDocument indexDocument) => Task.CompletedTask;
 
         public Task<IndexDocument?> GetAsync(Guid id, bool published) => Task.FromResult<IndexDocument?>(null);
 
         public Task DeleteAsync(Guid[] ids, bool published) => Task.CompletedTask;
+
         public Task DeleteAllAsync() => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
The `IIndexDocumentRepository` and `IIndexDocumentService` should be part of the search core service registrations, as they're required for the whole thing to boot.