### PR TITLE
Disable central version management for test site, and update umbraco version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,5 @@
     <PackageVersion Include="Umbraco.Cms.Infrastructure" Version="17.0.0" />
     <PackageVersion Include="Umbraco.Cms.Tests.Integration" Version="17.0.0" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="17.0.0" />
-    <PackageVersion Include="uSync" Version="17.0.2" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Web.TestSite.V17/Umbraco.Web.TestSite.V17.csproj
+++ b/src/Umbraco.Web.TestSite.V17/Umbraco.Web.TestSite.V17.csproj
@@ -4,16 +4,17 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <CompressionEnabled>false</CompressionEnabled> <!-- Disable compression. E.g. for umbraco backoffice files. These files should be precompressed by node and not let dotnet handle it -->
+        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms" />
-        <PackageReference Include="uSync" />
+        <PackageReference Include="Umbraco.Cms" Version="17.2.0-rc"/>
+        <PackageReference Include="uSync" Version="17.0.2"/>
     </ItemGroup>
 
     <ItemGroup>
         <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
-        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
+        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3"/>
         <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))"/>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco.Cms.Search/issues/40 for our own test site
# Notes
- Disables central package version management, this also aligns with the main CMS repository.
- Updates the test version to the latest 17.2.0-rc, which includes https://github.com/umbraco/Umbraco-CMS/pull/21455