### PR TITLE
Refactor culture state to workspace context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,6 +366,12 @@ Repositories abstract API calls and provide clean interfaces for UI components. 
 
 10. **Server-Driven State**: UI state should be derived from server health status (e.g., `healthStatus: 'Rebuilding'` → `state: 'loading'`). This keeps the UI synchronized with actual server state after reloads.
 
+11. **Invariant Culture in Examine Index**: The Examine provider uses `"none"` as the `Sys_Culture` field value for invariant documents. Sending `culture: "en-US"` to `SearchAsync` searches `Sys_Culture: "en-US" OR "none"`, so invariant content is always included. Sending `culture: null` returns invariant-only. Always send a real culture code from the client; use `"none"` as the fallback for invariant-only contexts.
+
+12. **Culture State on Workspace Context**: The `UmbSearchWorkspaceContext` owns `selectedCulture` state (observable + getter/setter). The search box writes it, entity actions read it via `getContext()`. Don't read culture from `window.location.href` — use the workspace context as the source of truth. URL params (`?culture=`) are for persistence/bookmarking only.
+
+13. **Examine Client Cross-Package Imports**: The Examine Client can import from `@umbraco-cms/search/settings` (e.g., `UMB_SEARCH_WORKSPACE_CONTEXT`) via tsconfig path mappings. Both `settings` and `global` paths are needed since settings depends on global transitively. Vite externalizes these; the importmap resolves at runtime.
+
 ## Coding Conventions
 
 - Follow Umbraco CMS coding standards (StyleCop, .editorconfig)

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/workspace/search/search-workspace.context.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/workspace/search/search-workspace.context.ts
@@ -16,6 +16,7 @@ import {
   type UmbRoutableWorkspaceContext,
 } from '@umbraco-cms/backoffice/workspace';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 
 export class UmbSearchWorkspaceContext
   extends UmbEntityNamedDetailWorkspaceContextBase<UmbSearchIndex, UmbSearchDetailRepository>
@@ -27,6 +28,17 @@ export class UmbSearchWorkspaceContext
   );
   public readonly healthStatus = this._data.createObservablePartOfPersisted((x) => x?.healthStatus);
   public readonly state = this._data.createObservablePartOfCurrent((x) => x?.state);
+
+  #selectedCulture = new UmbStringState(undefined);
+  public readonly selectedCulture = this.#selectedCulture.asObservable();
+
+  getSelectedCulture(): string | undefined {
+    return this.#selectedCulture.getValue();
+  }
+
+  setSelectedCulture(culture: string | undefined) {
+    this.#selectedCulture.setValue(culture);
+  }
 
   constructor(host: UmbControllerHost) {
     super(host, {

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/src/show-fields.entity-action.ts
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/src/show-fields.entity-action.ts
@@ -1,13 +1,16 @@
 import { fieldsRouteBuilder } from './fields-route-provider.element.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_SEARCH_WORKSPACE_CONTEXT } from '@umbraco-cms/search/settings';
 
 export class UmbSearchExamineShowFieldsEntityAction extends UmbEntityActionBase<never> {
-  // eslint-disable-next-line @typescript-eslint/require-await
   override async getHref() {
     const unique = this.args.unique ?? null;
     if (!unique) return '#';
 
-    const culture = new URL(window.location.href).searchParams.get('culture') ?? '_';
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const workspaceContext = await this.getContext(UMB_SEARCH_WORKSPACE_CONTEXT);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const culture = workspaceContext?.getSelectedCulture() ?? 'none';
 
     return fieldsRouteBuilder?.({ documentUnique: unique, culture }) ?? '#';
   }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/src/show-fields.modal.ts
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/src/show-fields.modal.ts
@@ -45,17 +45,11 @@ export class UmbSearchExamineShowFieldsModal extends UmbModalBaseElement<ShowFie
 
     this._cultureDocuments = (data?.documents ?? []).map((doc) => this.#mapCultureDocument(doc));
 
-    // sort so the selected culture comes first (if present)
+    // Set active tab to the preferred culture if it exists, otherwise default to the first
     const preferredCulture = this.data?.culture;
-    if (preferredCulture) {
-      this._cultureDocuments.sort((a, b) => {
-        const aMatch = a.culture === preferredCulture ? -1 : 0;
-        const bMatch = b.culture === preferredCulture ? -1 : 0;
-        return aMatch - bMatch;
-      });
-    }
-
-    this._activeCulture = this._cultureDocuments[0]?.culture;
+    const hasPreferred =
+      preferredCulture && this._cultureDocuments.some((d) => d.culture === preferredCulture);
+    this._activeCulture = hasPreferred ? preferredCulture : this._cultureDocuments[0]?.culture;
     this._isLoading = false;
   }
 

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/tsconfig.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@umbraco-cms/search/settings": ["../../Umbraco.Cms.Search.Core.Client/Client/src/settings/index.ts"],
+      "@umbraco-cms/search/global": ["../../Umbraco.Cms.Search.Core.Client/Client/src/global/index.ts"]
+    },
     "types": ["@umbraco-cms/backoffice/extension-types"]
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary
- Move culture state from URL parsing (`window.location.href`) and local `UmbStringState` into `UmbSearchWorkspaceContext` as single source of truth
- Entity action reads culture from workspace context via `getContext()` instead of parsing URL params
- Fix modal tab ordering: set active tab to preferred culture without reordering the array (stable tab order)
- Add tsconfig path mappings for Examine Client to import `UMB_SEARCH_WORKSPACE_CONTEXT` from Core Client

## Test plan
- [x] Search for documents in a multi-culture index, verify culture dropdown works and search results update
- [x] Click "Show Fields" on a search result — modal opens with correct culture tab active
- [x] Switch culture, click "Show Fields" again — new culture tab is active, tab order unchanged
- [x] Copy modal URL, open in new tab — deep link loads with correct culture
- [ ] Test with invariant-only index (no culture dropdown) — fields modal still works
- [x] Verify `npm run build` passes for both workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)