### PR TITLE
Book template CSS refinement

### DIFF
--- a/src/Umbraco.Web.TestSite.V17/Views/books.cshtml
+++ b/src/Umbraco.Web.TestSite.V17/Views/books.cshtml
@@ -11,9 +11,10 @@
 	<script>window.__CULTURE__ = "@culture";</script>
 	<script src="js/script.js" asp-append-version="true"></script>
 	<style>
+:root { color-scheme: light dark; }
 body {
-	background-color: oldlace;
-	color: black;
+	background-color: light-dark(oldlace, #121212);
+	color: light-dark(#121212, oldlace);
 	font-family: 'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif;
 	margin: auto;
 	max-width: 1200px;


### PR DESCRIPTION
On the test website, the default Times New Roman font was making me cry. 😭

I felt going for an old book feel, making use of the "Old Style" font stack (from <https://modernfontstacks.com>).

<img width="1979" height="831" alt="Screenshot 2026-02-12 163623" src="https://github.com/user-attachments/assets/ba08eeb7-161e-4b8f-a94d-1e70d41f4889" />
