### PR TITLE
Make the system field content indexer explicitly injectable

### DIFF
--- a/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -37,6 +37,7 @@ public static class UmbracoBuilderExtensions
 
         builder.Services.AddTransient<IContentIndexer, SystemFieldsContentIndexer>();
         builder.Services.AddTransient<IContentIndexer, PropertyValueFieldsContentIndexer>();
+        builder.Services.AddTransient<ISystemFieldsContentIndexer, SystemFieldsContentIndexer>();
 
         builder.Services.AddTransient<IDateTimeOffsetConverter, DateTimeOffsetConverter>();
         builder.Services.AddTransient<IContentProtectionProvider, ContentProtectionProvider>();


### PR DESCRIPTION
The `ISystemFieldsContentIndexer` is currently not registered in the services collection, making it unnecessarily hard to access it. This PR adds it.

At this time, one must take a dependency on content indexers (`IEnumerable<IContentIndexer> contentIndexers`) and iterate the collection to find the system fields content indexer (`contentIndexers.OfType<ISystemFieldsContentIndexer>().Single()`). This is both inefficient and based on assumtions.