### PR TITLE
Add an option to disable the default Examine indexes

### DIFF
--- a/docs/examine-provider.md
+++ b/docs/examine-provider.md
@@ -94,3 +94,22 @@ If all (applicable) facet values should be included for all groups in the search
 ### Max facet values
 
 The Examine search provider limits the number of resulting facet values within a facet group to 100. This limit can be changed using `SearcherOptions.MaxFacetValues`.
+
+## Optimizing server resources
+
+If Umbraco Search powers both frontend search, backoffice search and the Delivery API (if applicable), the default Examine indexes from Umbraco CMS are no longer in use. However, Umbraco CMS continues to keep them up-to-date with content changes.
+
+Since this is a waste of server resources, the default Examine indexes can be explicitly disabled by means of composition:
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Search.Provider.Examine.DependencyInjection;
+
+namespace Site.DependencyInjection;
+
+public class DisableDefaultIndexesComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.DisableDefaultExamineIndexes();
+}
+```

--- a/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -16,11 +16,16 @@ using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Infrastructure.Examine;
 using Umbraco.Cms.Search.Provider.Examine.NotificationHandlers;
+using Umbraco.Cms.Search.Provider.Examine.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Search.Provider.Examine.DependencyInjection;
 
 public static class UmbracoBuilderExtensions
 {
+    /// <summary>
+    /// Adds the Umbraco Search provider for Examine.
+    /// </summary>
     public static IUmbracoBuilder AddExamineSearchProvider(this IUmbracoBuilder builder)
     {
         builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(Core.Constants.IndexAliases.DraftContent, _ => { });
@@ -60,6 +65,23 @@ public static class UmbracoBuilderExtensions
 
             opt.OperationFilter<ExamineOperationSecurityFilter>();
         });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Disables the handling of the default Examine indexes from Umbraco Core.
+    /// </summary>
+    /// <remarks>
+    /// This prevents Umbraco from maintaining the default Examine indexes, thus freeing up server resources.
+    ///
+    /// Only use this if the default Examine indexes are no longer used; that is, if Umbraco Search powers both
+    /// frontend search, backoffice search and the Delivery API (when applicable).
+    /// </remarks>
+    public static IUmbracoBuilder DisableDefaultExamineIndexes(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddSingleton<ExamineManager>();
+        builder.Services.AddUnique<IExamineManager, MaskedCoreIndexesExamineManager>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/MaskedCoreIndexesExamineManager.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/MaskedCoreIndexesExamineManager.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Examine;
+
+namespace Umbraco.Cms.Search.Provider.Examine.Services;
+
+internal sealed class MaskedCoreIndexesExamineManager : IExamineManager
+{
+    private readonly string[] _coreIndexes =
+    [
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.DeliveryApiContentIndexName,
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.ExternalIndexName,
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.InternalIndexName,
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.MembersIndexName,
+    ];
+
+    private readonly ExamineManager _inner;
+
+    public MaskedCoreIndexesExamineManager(ExamineManager inner)
+        => _inner = inner;
+
+    public void Dispose()
+        => _inner.Dispose();
+
+    public bool TryGetIndex(string indexName, [MaybeNullWhen(false)] [UnscopedRef] out IIndex index)
+    {
+        if (_coreIndexes.Contains(indexName) is false)
+        {
+            return _inner.TryGetIndex(indexName, out index);
+        }
+
+        index = null;
+        return false;
+    }
+
+    public bool TryGetSearcher(string searcherName, [MaybeNullWhen(false)] [UnscopedRef] out ISearcher searcher)
+        => _inner.TryGetSearcher(searcherName, out searcher);
+
+    public IEnumerable<IIndex> Indexes
+        => _inner.Indexes.Where(index => _coreIndexes.Contains(index.Name) is false).ToArray();
+
+    public IEnumerable<ISearcher> RegisteredSearchers
+        => _inner.RegisteredSearchers;
+}


### PR DESCRIPTION
What the title said; this makes it possible to stop Umbraco from keeping the default Examine indexes in sync, in case they are no longer needed.

### Testing this PR

Add the composer from the docs update to the test site, and verify that things continue to work as per usual - that is:

- Frontend and backoffice search
- The Delivery API
- Document publishing