### PR TITLE
Support custom entity indexing without IContentChangeStrategy

### DIFF
--- a/docs/custom-entity-indexing.md
+++ b/docs/custom-entity-indexing.md
@@ -1,0 +1,199 @@
+# A custom index for non-Umbraco data
+
+> [!NOTE]
+> If you only need extra fields on an existing content, media, or member index, use `IContentIndexer` instead. This page is for entirely separate entity types.
+
+This is intended to be comparable to the Docs page on [custom Examine indexes](https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#a-custom-index-for-non-umbraco-data), but using the new Umbraco Search framework instead of coding directly against Examine.
+
+Rather than coding directly against Examine's Lucene APIs, Umbraco Search provides a provider-agnostic abstraction. You interact with `IIndexer` and `ISearcher` regardless of what search technology is underneath.
+
+The examples in this article use a `Book` entity to illustrate the pattern.
+
+---
+
+## 1. Register the Lucene index
+
+Register a Lucene index for the new entity in a composer, giving it a unique alias:
+
+```csharp
+builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(
+    "Umb_Books", _ => { });
+```
+
+> [!TIP]
+> Use the `Umb_` prefix to stay consistent with the built-in Umbraco indexes.
+
+---
+
+## 2. Map your entity to index fields
+
+Instead of `ValueSet.FromObject()`, map properties to typed `IndexField` instances. Define a service to wrap the indexing operations:
+
+```csharp
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Search.Core;
+using Umbraco.Cms.Search.Core.Extensions;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Services;
+
+namespace MyProject.Search;
+
+internal sealed class BookIndexingService(IIndexer indexer)
+{
+    public Task AddOrUpdateAsync(Book book)
+    {
+        IndexField[] fields =
+        [
+            // System fields used by the backoffice
+            new(Constants.FieldNames.Id,   new IndexValue { Keywords = [book.Id.AsKeyword()] }, Culture: null, Segment: null),
+            new(Constants.FieldNames.Name, new IndexValue { TextsR1  = [book.Title] },         Culture: null, Segment: null),
+            new(Constants.FieldNames.Icon, new IndexValue { Keywords  = ["icon-book"] },        Culture: null, Segment: null),
+
+            // Custom fields
+            new("author",    new IndexValue { Keywords  = [book.Author] },      Culture: null, Segment: null),
+            new("published", new IndexValue { Integers  = [book.PublishedYear] }, Culture: null, Segment: null),
+        ];
+
+        return indexer.AddOrUpdateAsync(
+            indexAlias: "Umb_Books",
+            id: book.Id,
+            objectType: UmbracoObjectTypes.Unknown,
+            variations: [new Variation(null, null)],
+            fields: fields,
+            protection: null);
+    }
+
+    public Task DeleteAsync(Guid bookId)
+        => indexer.DeleteAsync("Umb_Books", [bookId]);
+}
+```
+
+> [!TIP]
+> The `Umb_Id`, `Umb_Name`, and `Umb_Icon` system fields are used by the backoffice. For Umbraco content indexes these are indexed automatically by the framework, but for custom entity indexes you must include them yourself. `Umb_Id` is required for the "Show Fields" action to work; `Umb_Name` and `Umb_Icon` control what appears in the search results table.
+
+**Field type guide:**
+
+| Data | `IndexValue` property | Filter type |
+|---|---|---|
+| Full-text (title, body) | `TextsR1` / `TextsR2` / `TextsR3` / `Texts` | `TextFilter` |
+| Exact match, IDs, categories | `Keywords` | `KeywordFilter` |
+| Whole numbers | `Integers` | `IntegerRangeFilter` / `IntegerExactFilter` |
+| Decimals | `Decimals` | `DecimalRangeFilter` / `DecimalExactFilter` |
+| Dates | `DateTimeOffsets` | `DateTimeOffsetRangeFilter` / `DateTimeOffsetExactFilter` |
+
+For entities without culture variants, pass a single `Variation(null, null)`. Pass `UmbracoObjectTypes.Unknown` for entity types not known to Umbraco core.
+
+> [!WARNING]
+> Filter type must match field type. Using `KeywordFilter` on a `Texts` field (or vice versa) returns zero results.
+
+---
+
+## 3. Keep the index in sync
+
+Register notification handlers to index and remove documents as entities are saved and deleted:
+
+```csharp
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace MyProject.Search;
+
+internal sealed class BookNotificationHandler(BookIndexingService books)
+    : INotificationAsyncHandler<BookSavedNotification>,
+      INotificationAsyncHandler<BookDeletedNotification>
+{
+    public async Task HandleAsync(BookSavedNotification notification, CancellationToken cancellationToken)
+    {
+        foreach (Book book in notification.SavedEntities)
+        {
+            await books.AddOrUpdateAsync(book);
+        }
+    }
+
+    public async Task HandleAsync(BookDeletedNotification notification, CancellationToken cancellationToken)
+    {
+        foreach (Book book in notification.DeletedEntities)
+        {
+            await books.DeleteAsync(book.Id);
+        }
+    }
+}
+```
+
+---
+
+## 4. Support backoffice rebuild
+
+To enable the **Rebuild** button in the backoffice Search section, implement `IIndexRebuildStrategy`:
+
+```csharp
+using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Services;
+
+namespace MyProject.Search;
+
+internal sealed class BookRebuildStrategy(IBookRepository bookRepository, BookIndexingService books)
+    : IIndexRebuildStrategy
+{
+    public async Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken)
+    {
+        foreach (Book book in await bookRepository.GetAllAsync())
+        {
+            await books.AddOrUpdateAsync(book);
+        }
+    }
+}
+```
+
+> [!NOTE]
+> `IIndexRebuildStrategy` handles only the rebuild concern. The built-in Umbraco content indexes use `IContentChangeStrategy` (which extends `IIndexRebuildStrategy`) to also track content changes — but for custom entities, `IIndexRebuildStrategy` is all you need.
+
+---
+
+## 5. Register everything
+
+Wire up all the pieces in a composer or builder extension method:
+
+```csharp
+using Examine.Lucene.Providers;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Examine;
+using Umbraco.Cms.Search.Core.Configuration;
+using Umbraco.Cms.Search.Provider.Examine.Services;
+
+namespace MyProject.Search;
+
+public static class UmbracoBuilderExtensions
+{
+    public static IUmbracoBuilder AddBookSearch(this IUmbracoBuilder builder)
+    {
+        // Register the Lucene index
+        builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(
+            "Umb_Books", _ => { });
+
+        // Register with the Search framework for backoffice visibility and rebuild support
+        builder.Services.Configure<IndexOptions>(options =>
+            options.RegisterIndex<IExamineIndexer, IExamineSearcher, BookRebuildStrategy>(
+                "Umb_Books", UmbracoObjectTypes.Unknown));
+
+        // Register services
+        builder.Services.AddTransient<BookIndexingService>();
+        builder.Services.AddTransient<BookRebuildStrategy>();
+
+        // Notification handlers
+        builder.AddNotificationAsyncHandler<BookSavedNotification, BookNotificationHandler>();
+        builder.AddNotificationAsyncHandler<BookDeletedNotification, BookNotificationHandler>();
+
+        return builder;
+    }
+}
+```
+
+`RegisterIndex` is what causes the index to appear in the backoffice Search section and makes the **Rebuild** button functional.
+
+---
+
+## Custom field types
+
+If your entity has properties that don't map to the built-in `IndexValue` types (for example, collections of GUIDs), follow the [custom extensibility guide](custom-extensibility.md) to create a custom `IndexValue` subclass and a corresponding `Indexer` subclass to handle it. The rest of this pattern remains unchanged.
+

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/repositories/search-query.server.data-source.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/repositories/search-query.server.data-source.ts
@@ -59,6 +59,7 @@ export class UmbSearchQueryServerDataSource extends UmbControllerBase {
       MediaType: 'media-type',
       MemberType: 'member-type',
       DataType: 'data-type',
+      FormsForm: 'forms-form',
     };
 
     return typeMap[objectType] || objectType.toLowerCase();

--- a/src/Umbraco.Cms.Search.Core/Configuration/IndexOptions.cs
+++ b/src/Umbraco.Cms.Search.Core/Configuration/IndexOptions.cs
@@ -1,7 +1,6 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Core.Models.Configuration;
 using Umbraco.Cms.Search.Core.Services;
-using Umbraco.Cms.Search.Core.Services.ContentIndexing;
 
 namespace Umbraco.Cms.Search.Core.Configuration;
 
@@ -9,10 +8,10 @@ public sealed class IndexOptions
 {
     private readonly Dictionary<string, IndexRegistration> _register = [];
 
-    public void RegisterIndex<TIndexer, TSearcher, TContentChangeStrategy>(string indexAlias, params UmbracoObjectTypes[] containedObjectTypes)
+    public void RegisterIndex<TIndexer, TSearcher, TIndexRebuildStrategy>(string indexAlias, params UmbracoObjectTypes[] containedObjectTypes)
         where TIndexer : class, IIndexer
         where TSearcher : class, ISearcher
-        where TContentChangeStrategy : class, IContentChangeStrategy
+        where TIndexRebuildStrategy : class, IIndexRebuildStrategy
     {
         ArgumentException.ThrowIfNullOrEmpty("Index alias cannot be empty", nameof(indexAlias));
         if (containedObjectTypes.Length is 0)
@@ -20,7 +19,7 @@ public sealed class IndexOptions
             throw new ArgumentException($"Index \"{indexAlias}\" must define at least one contained object type",  nameof(containedObjectTypes));
         }
 
-        _register[indexAlias] = new IndexRegistration(indexAlias, containedObjectTypes.Distinct(), typeof(TIndexer), typeof(TSearcher), typeof(TContentChangeStrategy));
+        _register[indexAlias] = new IndexRegistration(indexAlias, containedObjectTypes.Distinct(), typeof(TIndexer), typeof(TSearcher), typeof(TIndexRebuildStrategy));
     }
 
     public IndexRegistration[] GetIndexRegistrations()

--- a/src/Umbraco.Cms.Search.Core/Constants.cs
+++ b/src/Umbraco.Cms.Search.Core/Constants.cs
@@ -39,6 +39,8 @@ public static class Constants
 
         public const string ObjectType = $"{FieldPrefix}ObjectType";
 
+        public const string Icon = $"{FieldPrefix}Icon";
+
         public const string Tags = $"{FieldPrefix}Tags";
     }
 

--- a/src/Umbraco.Cms.Search.Core/Models/Configuration/IndexRegistration.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Configuration/IndexRegistration.cs
@@ -2,4 +2,4 @@
 
 namespace Umbraco.Cms.Search.Core.Models.Configuration;
 
-public record IndexRegistration(string IndexAlias, IEnumerable<UmbracoObjectTypes> ContainedObjectTypes, Type Indexer, Type Searcher, Type ContentChangeStrategy);
+public record IndexRegistration(string IndexAlias, IEnumerable<UmbracoObjectTypes> ContainedObjectTypes, Type Indexer, Type Searcher, Type IndexRebuildStrategy);

--- a/src/Umbraco.Cms.Search.Core/Models/Searching/Document.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Searching/Document.cs
@@ -4,4 +4,7 @@ namespace Umbraco.Cms.Search.Core.Models.Searching;
 
 public record Document(Guid Id, UmbracoObjectTypes ObjectType)
 {
+    public string? Name { get; init; }
+
+    public string? Icon { get; init; }
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IContentChangeStrategy.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IContentChangeStrategy.cs
@@ -1,10 +1,8 @@
-﻿using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Models.Indexing;
 
 namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
 
-public interface IContentChangeStrategy
+public interface IContentChangeStrategy : IIndexRebuildStrategy
 {
     Task HandleAsync(IEnumerable<IndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken);
-
-    Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken);
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/Indexers/SystemFieldsContentIndexer.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/Indexers/SystemFieldsContentIndexer.cs
@@ -57,6 +57,11 @@ internal sealed class SystemFieldsContentIndexer : ISystemFieldsContentIndexer
             new(Constants.FieldNames.SortOrder, new() { Integers = [content.SortOrder] }, null, null),
         };
 
+        if (string.IsNullOrEmpty(content.ContentType.Icon) is false)
+        {
+            fields.Add(new(Constants.FieldNames.Icon, new() { Keywords = [content.ContentType.Icon] }, null, null));
+        }
+
         fields.AddRange(GetCultureTagFields(content, cultures));
         fields.AddRange(GetCultureNameFields(content, cultures));
 

--- a/src/Umbraco.Cms.Search.Core/Services/IIndexRebuildStrategy.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/IIndexRebuildStrategy.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Search.Core.Models.Indexing;
+
+namespace Umbraco.Cms.Search.Core.Services;
+
+public interface IIndexRebuildStrategy
+{
+    Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken);
+}

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -158,8 +158,13 @@ public class Searcher : IExamineSearcher
         AddFacets(searchQuery, deduplicateFacets, culture, segment);
         AddSorters(searchQuery, sortersAsArray, culture, segment);
 
-        // We only need the IndexType and NodeId
-        var selectedFields = new HashSet<string> {Constants.SystemFields.IndexType, "__NodeId" };
+        var selectedFields = new HashSet<string>
+        {
+            Constants.SystemFields.IndexType,
+            "__NodeId",
+            FieldNameHelper.FieldName(Core.Constants.FieldNames.Name, Constants.FieldValues.TextsR1),
+            FieldNameHelper.FieldName(Core.Constants.FieldNames.Icon, Constants.FieldValues.Keywords),
+        };
         searchQuery.SelectFields(selectedFields);
 
         ISearchResults results;
@@ -522,16 +527,21 @@ public class Searcher : IExamineSearcher
 
         Enum.TryParse(objectTypeString, out UmbracoObjectTypes umbracoObjectType);
 
+        var name = item.Values.GetValueOrDefault(
+            FieldNameHelper.FieldName(Core.Constants.FieldNames.Name, Constants.FieldValues.TextsR1));
+        var icon = item.Values.GetValueOrDefault(
+            FieldNameHelper.FieldName(Core.Constants.FieldNames.Icon, Constants.FieldValues.Keywords));
+
         if (Guid.TryParse(item.Id, out Guid guidId))
         {
-            return new Document(guidId, umbracoObjectType);
+            return new Document(guidId, umbracoObjectType) { Name = name, Icon = icon };
         }
 
         // The id of an item may be appended with _{culture_{segment}, so strip those and map to guid.
         var indexofUnderscore = item.Id.IndexOf('_');
         var idWithOutCulture = item.Id.Remove(indexofUnderscore);
         return Guid.TryParse(idWithOutCulture, out Guid idWithoutCultureGuid)
-            ? new Document(idWithoutCultureGuid, umbracoObjectType)
+            ? new Document(idWithoutCultureGuid, umbracoObjectType) { Name = name, Icon = icon }
             : null;
     }
 


### PR DESCRIPTION
This PR enables custom entity indexing for non-Umbraco content (e.g. Umbraco Forms) by decoupling rebuild logic from content change tracking.

Whilst trying to set it up against Umbraco Forms I found that a lot of the concepts are focused around indexing specifically Umbraco content. This meant having to work around some of the constraints already in place for anything that wasn't an Umbraco entity, but also in Forms' case it *was* an `UmbracoObjectType` and not `Unknown`.

From a DX point of view, I imagine that most people who want to implement a custom index will likely look to the documentation, so I decided to approach this as if following the current [custom index for non-Umbraco data](https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#a-custom-index-for-non-umbraco-data) instructions in the docs.

With these changes in place, my setup in Forms looks something like this...

<details>
<summary>UmbracoBuilderExtensions.cs</summary>

```cs
public static IUmbracoBuilder AddUmbracoFormsExamine(this IUmbracoBuilder builder)
{
    // Existing implementation
    //...

    // Register the Lucene index
    builder.Services.AddExamineLuceneIndex<LuceneIndex, ConfigurationEnabledDirectoryFactory>(
        Core.Constants.ExamineIndex.FormsIndexName, _ => { });

    // Register with the Search framework for backoffice visibility and rebuild support
    builder.Services.Configure<Cms.Search.Core.Configuration.IndexOptions>(options =>
        options.RegisterIndex<IExamineIndexer, IExamineSearcher, FormRebuildStrategy>(
            Core.Constants.ExamineIndex.FormsIndexName, UmbracoObjectTypes.FormsForm));

    // Register services
    builder.Services.AddTransient<IFormIndexingService, FormIndexingService>();
    builder.Services.AddTransient<FormRebuildStrategy>();

    // Notification handlers
    builder.AddNotificationAsyncHandler<FormSavedNotification, FormNotificationHandler>();
    builder.AddNotificationAsyncHandler<FormDeletedNotification, FormNotificationHandler>();

    return builder;
}
```

</details>

<details>
<summary>FormIndexingService.cs</summary>

```cs
internal sealed class FormIndexingService : IFormIndexingService
{
    private readonly IIndexer _indexer;

    public FormIndexingService(IIndexer indexer)
        => _indexer = indexer;

    public Task AddOrUpdateAsync(Form form)
    {
        IndexField[] fields =
        [
            new(Cms.Search.Core.Constants.FieldNames.Id, new IndexValue { Keywords = [form.Id.AsKeyword()] }, Culture: null, Segment: null),
            new(Cms.Search.Core.Constants.FieldNames.Name, new IndexValue { TextsR1 = [form.Name] }, Culture: null, Segment: null),
            new(Cms.Search.Core.Constants.FieldNames.Icon, new IndexValue { Keywords = ["icon-autofill"] }, Culture: null, Segment: null),
            new("folderId",   new IndexValue { Keywords = [form.FolderId?.ToString()!] }, Culture: null, Segment: null),
            new("createDate", new IndexValue { DateTimeOffsets = [new DateTimeOffset(DateTime.SpecifyKind(form.Created, DateTimeKind.Utc))] }, Culture: null, Segment: null),
            new("updateDate", new IndexValue { DateTimeOffsets = [new DateTimeOffset(DateTime.SpecifyKind(form.Updated, DateTimeKind.Utc))] }, Culture: null, Segment: null),
            new("creatorId",  new IndexValue { Integers = [form.CreatedBy ?? 0] }, Culture: null, Segment: null),
            new("writerId",   new IndexValue { Integers = [form.UpdatedBy ?? 0] }, Culture: null, Segment: null),
        ];

        return _indexer.AddOrUpdateAsync(
            indexAlias: Core.Constants.ExamineIndex.FormsIndexName,
            id: form.Id,
            objectType: UmbracoObjectTypes.FormsForm,
            variations: [new Variation(null, null)],
            fields: fields,
            protection: null);
    }

    public Task DeleteAsync(Guid formId)
        => _indexer.DeleteAsync(Core.Constants.ExamineIndex.FormsIndexName, [formId]);
}
```
</details>

<details>
<summary>FormRebuildStrategy.cs</summary>

```cs
public class FormRebuildStrategy : IIndexRebuildStrategy
{
    private readonly IFormService _formService;
    private readonly IFormIndexingService _formIndexingService;

    public FormRebuildStrategy(
        IFormService formService,
        IFormIndexingService formIndexingService)
    {
        _formService = formService;
        _formIndexingService = formIndexingService;
    }

    public async Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken)
    {
        var forms = _formService.Get();
        foreach (var form in forms)
        {
            // The indexing handler will take care of adding the form to the index.
            await _formIndexingService.AddOrUpdateAsync(form);
        }
    }
}
```
</details>

<details>
<summary>FormNotificationHandler.cs</summary>

```cs
public class FormNotificationHandler : INotificationAsyncHandler<FormSavedNotification>,
  INotificationAsyncHandler<FormDeletedNotification>
{
    private readonly IFormIndexingService _formIndexingService;

    public FormNotificationHandler(IFormIndexingService formIndexingService)
        => _formIndexingService = formIndexingService;

    public async Task HandleAsync(FormSavedNotification notification, CancellationToken cancellationToken)
    {
        foreach (Form form in notification.SavedEntities)
        {
            await _formIndexingService.AddOrUpdateAsync(form);
        }
    }

    public async Task HandleAsync(FormDeletedNotification notification, CancellationToken cancellationToken)
    {
        foreach (Form form in notification.DeletedEntities)
        {
            await _formIndexingService.DeleteAsync(form.Id);
        }
    }
}
```
</details>

This does mean that there are a small number of breaking changes to support more generic indexing:
1. `IndexRegistration.ContentChangeStrategy` renamed to `IndexRegistration.IndexRebuildStrategy`
2. `IContentChangeStrategy` no longer declares `RebuildAsync` directly, it's inherited from `IIndexRebuildStrategy`.
3. `IndexOptions.RegisterIndex` generic constraint changed from `where TContentChangeStrategy : class, IContentChangeStrategy` to `where TIndexRebuildStrategy : class, IIndexRebuildStrategy`
4. `SearchApiController` constructor — removed `IEntityService` and `IVariationContextAccessor` parameters, since document name and icon are now read directly from the search index rather than looked up via `EntityService`. This is required so non-Umbraco entities (which `EntityService` can't resolve) display correctly in search results.

I have included a Markdown file in the PR which details the updated "custom index for non-Umbraco data" flow. This should hopefully help when looking to add to the Docs or have people test this out more widely.