### PR TITLE
Distinguish harder between content indexes and "other" indexes

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Configuration/IndexOptions.cs
+++ b/src/Umbraco.Cms.Search.Core/Configuration/IndexOptions.cs
@@ -9,7 +9,16 @@ public sealed class IndexOptions
 {
     private readonly Dictionary<string, IndexRegistration> _register = [];
 
-    public void RegisterIndex<TIndexer, TSearcher, TContentChangeStrategy>(string indexAlias, params UmbracoObjectTypes[] containedObjectTypes)
+    public void RegisterIndex<TIndexer, TSearcher>(string indexAlias)
+        where TIndexer : class, IIndexer
+        where TSearcher : class, ISearcher
+    {
+        ArgumentException.ThrowIfNullOrEmpty("Index alias cannot be empty", nameof(indexAlias));
+
+        _register[indexAlias] = new IndexRegistration(indexAlias, typeof(TIndexer), typeof(TSearcher));
+    }
+
+    public void RegisterContentIndex<TIndexer, TSearcher, TContentChangeStrategy>(string indexAlias, params UmbracoObjectTypes[] containedObjectTypes)
         where TIndexer : class, IIndexer
         where TSearcher : class, ISearcher
         where TContentChangeStrategy : class, IContentChangeStrategy
@@ -20,12 +29,15 @@ public sealed class IndexOptions
             throw new ArgumentException($"Index \"{indexAlias}\" must define at least one contained object type",  nameof(containedObjectTypes));
         }
 
-        _register[indexAlias] = new IndexRegistration(indexAlias, containedObjectTypes.Distinct(), typeof(TIndexer), typeof(TSearcher), typeof(TContentChangeStrategy));
+        _register[indexAlias] = new ContentIndexRegistration(indexAlias, typeof(TIndexer), typeof(TSearcher), typeof(TContentChangeStrategy), containedObjectTypes.Distinct());
     }
 
-    public IndexRegistration[] GetIndexRegistrations()
-        => _register.Values.ToArray();
+    public ContentIndexRegistration[] GetContentIndexRegistrations()
+        => _register.Values.OfType<ContentIndexRegistration>().ToArray();
 
     public IndexRegistration? GetIndexRegistration(string indexAlias)
         => _register.TryGetValue(indexAlias, out IndexRegistration? indexRegistration) ? indexRegistration : null;
+
+    public ContentIndexRegistration? GetContentIndexRegistration(string indexAlias)
+        => GetIndexRegistration(indexAlias) as ContentIndexRegistration;
 }

--- a/src/Umbraco.Cms.Search.Core/Controllers/GetAllIndexesApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/GetAllIndexesApiController.cs
@@ -34,7 +34,7 @@ public class GetAllIndexesApiController : ApiControllerBase
     public async Task<IActionResult> Indexes()
     {
         List<IndexViewModel> indexes = [];
-        foreach (IndexRegistration indexRegistration in _options.GetIndexRegistrations())
+        foreach (ContentIndexRegistration indexRegistration in _options.GetContentIndexRegistrations())
         {
             if (TryGetIndexer(_serviceProvider, indexRegistration.Indexer, _logger, out IIndexer? indexer) is false)
             {

--- a/src/Umbraco.Cms.Search.Core/Controllers/GetIndexApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/GetIndexApiController.cs
@@ -39,7 +39,7 @@ public class GetIndexApiController : ApiControllerBase
             return BadRequest("The indexAlias parameter must be provided and cannot be empty.");
         }
 
-        IndexRegistration? indexRegistration = _options.GetIndexRegistration(indexAlias);
+        ContentIndexRegistration? indexRegistration = _options.GetContentIndexRegistration(indexAlias);
         if (indexRegistration is null)
         {
             return NotFound("The specified index alias was not found.");

--- a/src/Umbraco.Cms.Search.Core/Controllers/RebuildIndexApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/RebuildIndexApiController.cs
@@ -32,7 +32,7 @@ public class RebuildIndexApiController : ApiControllerBase
         }
 
         // Check if the index exists before calling the service
-        IndexRegistration? indexRegistration = _options.GetIndexRegistration(indexAlias);
+        ContentIndexRegistration? indexRegistration = _options.GetContentIndexRegistration(indexAlias);
         if (indexRegistration is null)
         {
             return NotFound("The specified index alias was not found.");

--- a/src/Umbraco.Cms.Search.Core/Models/Configuration/ContentIndexRegistration.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Configuration/ContentIndexRegistration.cs
@@ -1,0 +1,6 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Search.Core.Models.Configuration;
+
+public record ContentIndexRegistration(string IndexAlias, Type Indexer, Type Searcher, Type ContentChangeStrategy, IEnumerable<UmbracoObjectTypes> ContainedObjectTypes)
+    : IndexRegistration(IndexAlias, Indexer, Searcher);

--- a/src/Umbraco.Cms.Search.Core/Models/Configuration/IndexRegistration.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Configuration/IndexRegistration.cs
@@ -1,5 +1,3 @@
-﻿using Umbraco.Cms.Core.Models;
+﻿namespace Umbraco.Cms.Search.Core.Models.Configuration;
 
-namespace Umbraco.Cms.Search.Core.Models.Configuration;
-
-public record IndexRegistration(string IndexAlias, IEnumerable<UmbracoObjectTypes> ContainedObjectTypes, Type Indexer, Type Searcher, Type ContentChangeStrategy);
+public record IndexRegistration(string IndexAlias, Type Indexer, Type Searcher);

--- a/src/Umbraco.Cms.Search.Core/Models/Indexing/ContentIndexInfo.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Indexing/ContentIndexInfo.cs
@@ -3,4 +3,4 @@ using Umbraco.Cms.Search.Core.Services;
 
 namespace Umbraco.Cms.Search.Core.Models.Indexing;
 
-public record IndexInfo(string IndexAlias, IEnumerable<UmbracoObjectTypes> ContainedObjectTypes, IIndexer Indexer);
+public record ContentIndexInfo(string IndexAlias, IEnumerable<UmbracoObjectTypes> ContainedObjectTypes, IIndexer Indexer);

--- a/src/Umbraco.Cms.Search.Core/NotificationHandlers/RebuildIndexesNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/NotificationHandlers/RebuildIndexesNotificationHandler.cs
@@ -39,7 +39,7 @@ internal sealed class RebuildIndexesNotificationHandler :
         _logger.LogInformation("Rebuilding search indexes after language deletion...");
         await _indexDocumentService.DeleteAllAsync();
 
-        foreach (IndexRegistration indexRegistration in _options.GetIndexRegistrations())
+        foreach (ContentIndexRegistration indexRegistration in _options.GetContentIndexRegistrations())
         {
             if (indexRegistration.ContainedObjectTypes.Contains(UmbracoObjectTypes.Document))
             {
@@ -67,7 +67,7 @@ internal sealed class RebuildIndexesNotificationHandler :
                 continue;
             }
 
-            foreach (IndexRegistration indexRegistration in _options.GetIndexRegistrations())
+            foreach (ContentIndexRegistration indexRegistration in _options.GetContentIndexRegistrations())
             {
                 if (indexRegistration.ContainedObjectTypes.Contains(objectType))
                 {

--- a/src/Umbraco.Cms.Search.Core/Notifications/ContentIndexingNotification.cs
+++ b/src/Umbraco.Cms.Search.Core/Notifications/ContentIndexingNotification.cs
@@ -4,23 +4,23 @@ using Umbraco.Cms.Search.Core.Models.Indexing;
 
 namespace Umbraco.Cms.Search.Core.Notifications;
 
-public sealed class IndexingNotification : ICancelableNotification
+public sealed class ContentIndexingNotification : ICancelableNotification
 {
-    public IndexingNotification(
-        IndexInfo indexInfo,
+    public ContentIndexingNotification(
+        string indexAlias,
         Guid id,
         UmbracoObjectTypes objectType,
         IEnumerable<Variation> variations,
         IEnumerable<IndexField> fields)
     {
-        IndexInfo = indexInfo;
+        IndexAlias = indexAlias;
         Id = id;
         ObjectType = objectType;
         Variations = variations;
         Fields = fields;
     }
 
-    public IndexInfo IndexInfo { get; }
+    public string IndexAlias { get; }
 
     public Guid Id { get; }
 

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentChangeStrategyBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentChangeStrategyBase.cs
@@ -63,6 +63,6 @@ internal abstract class ContentChangeStrategyBase
         while (descendants.Length == ContentEnumerationPageSize);
     }
 
-    protected void LogIndexRebuildCancellation(IndexInfo indexInfo)
+    protected void LogIndexRebuildCancellation(ContentIndexInfo indexInfo)
         => _logger.LogInformation("Cancellation requested for rebuild of index: {indexAlias}", indexInfo.IndexAlias);
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentIndexingService.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentIndexingService.cs
@@ -38,7 +38,7 @@ internal sealed class ContentIndexingService : IContentIndexingService
 
     public void Rebuild(string indexAlias)
     {
-        IndexRegistration? indexRegistration = _indexOptions.GetIndexRegistration(indexAlias);
+        ContentIndexRegistration? indexRegistration = _indexOptions.GetContentIndexRegistration(indexAlias);
         if (indexRegistration is null)
         {
             _logger.LogError("Cannot rebuild index - no index registration found for alias: {indexAlias}", indexAlias);
@@ -52,21 +52,21 @@ internal sealed class ContentIndexingService : IContentIndexingService
     {
         ContentChange[] changesAsArray = changes as ContentChange[] ?? changes.ToArray();
 
-        IEnumerable<IGrouping<Type, IndexRegistration>> indexRegistrationsByStrategyType = _indexOptions
-            .GetIndexRegistrations()
+        IEnumerable<IGrouping<Type, ContentIndexRegistration>> indexRegistrationsByStrategyType = _indexOptions
+            .GetContentIndexRegistrations()
             .GroupBy(r => r.ContentChangeStrategy);
 
-        foreach (IGrouping<Type, IndexRegistration> group in indexRegistrationsByStrategyType)
+        foreach (IGrouping<Type, ContentIndexRegistration> group in indexRegistrationsByStrategyType)
         {
             if (TryGetContentChangeStrategy(group.Key, out IContentChangeStrategy? contentChangeStrategy) is false)
             {
                 continue;
             }
 
-            IndexInfo[] indexInfos = group
+            ContentIndexInfo[] indexInfos = group
                 .Select(g =>
                     TryGetIndexer(g.Indexer, out IIndexer? indexer)
-                        ? new IndexInfo(g.IndexAlias, g.ContainedObjectTypes, indexer)
+                        ? new ContentIndexInfo(g.IndexAlias, g.ContainedObjectTypes, indexer)
                         : null)
                 .WhereNotNull()
                 .ToArray();
@@ -81,7 +81,7 @@ internal sealed class ContentIndexingService : IContentIndexingService
         }
     }
 
-    private async Task RebuildAsync(IndexRegistration indexRegistration, CancellationToken cancellationToken)
+    private async Task RebuildAsync(ContentIndexRegistration indexRegistration, CancellationToken cancellationToken)
     {
         if (TryGetContentChangeStrategy(indexRegistration.ContentChangeStrategy, out IContentChangeStrategy? contentChangeStrategy) is false
             || TryGetIndexer(indexRegistration.Indexer, out IIndexer? indexer) is false)
@@ -91,7 +91,7 @@ internal sealed class ContentIndexingService : IContentIndexingService
 
         await _eventAggregator.PublishAsync(new IndexRebuildStartingNotification(indexRegistration.IndexAlias), cancellationToken);
 
-        await contentChangeStrategy.RebuildAsync(new IndexInfo(indexRegistration.IndexAlias, indexRegistration.ContainedObjectTypes, indexer), cancellationToken);
+        await contentChangeStrategy.RebuildAsync(new ContentIndexInfo(indexRegistration.IndexAlias, indexRegistration.ContainedObjectTypes, indexer), cancellationToken);
 
         await _eventAggregator.PublishAsync(new IndexRebuildCompletedNotification(indexRegistration.IndexAlias), cancellationToken);
     }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DraftContentChangeStrategy.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DraftContentChangeStrategy.cs
@@ -39,9 +39,9 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         _eventAggregator = eventAggregator;
     }
 
-    public async Task HandleAsync(IEnumerable<IndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
+    public async Task HandleAsync(IEnumerable<ContentIndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
     {
-        IndexInfo[] indexInfosAsArray = indexInfos as IndexInfo[] ?? indexInfos.ToArray();
+        ContentIndexInfo[] indexInfosAsArray = indexInfos as ContentIndexInfo[] ?? indexInfos.ToArray();
 
         // get the relevant changes for this change strategy
         ContentChange[] changesAsArray = changes.Where(change =>
@@ -79,7 +79,7 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         await RemoveFromIndexAsync(indexInfosAsArray, pendingRemovals);
     }
 
-    public async Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken)
+    public async Task RebuildAsync(ContentIndexInfo indexInfo, CancellationToken cancellationToken)
     {
         await indexInfo.Indexer.ResetAsync(indexInfo.IndexAlias);
 
@@ -142,9 +142,9 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         }
     }
 
-    private async Task<bool> UpdateIndexAsync(IndexInfo[] indexInfos, ContentChange change, IContentBase content, CancellationToken cancellationToken)
+    private async Task<bool> UpdateIndexAsync(ContentIndexInfo[] indexInfos, ContentChange change, IContentBase content, CancellationToken cancellationToken)
     {
-        IndexInfo[] applicableIndexInfos = indexInfos.Where(info => info.ContainedObjectTypes.Contains(change.ObjectType)).ToArray();
+        ContentIndexInfo[] applicableIndexInfos = indexInfos.Where(info => info.ContainedObjectTypes.Contains(change.ObjectType)).ToArray();
         if(applicableIndexInfos.Length is 0)
         {
             return true;
@@ -182,7 +182,7 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         return result;
     }
 
-    private async Task UpdateIndexDescendantsAsync<T>(IndexInfo[] indexInfos, T[] descendants, UmbracoObjectTypes objectType, CancellationToken cancellationToken)
+    private async Task UpdateIndexDescendantsAsync<T>(ContentIndexInfo[] indexInfos, T[] descendants, UmbracoObjectTypes objectType, CancellationToken cancellationToken)
         where T : IContentBase
     {
         foreach (T descendant in descendants)
@@ -191,7 +191,7 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         }
     }
 
-    private async Task<bool> UpdateIndexAsync(IndexInfo[] indexInfos, IContentBase content, UmbracoObjectTypes objectType, CancellationToken cancellationToken)
+    private async Task<bool> UpdateIndexAsync(ContentIndexInfo[] indexInfos, IContentBase content, UmbracoObjectTypes objectType, CancellationToken cancellationToken)
     {
         IndexField[]? fields = (await _contentIndexingDataCollectionService.CollectAsync(content, false, cancellationToken))?.ToArray();
         if (fields is null)
@@ -213,9 +213,9 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
                 .Select(culture => new Variation(culture, null))
                 .ToArray();
 
-        foreach (IndexInfo indexInfo in indexInfos)
+        foreach (ContentIndexInfo indexInfo in indexInfos)
         {
-            var notification = new IndexingNotification(indexInfo, content.Key, UmbracoObjectTypes.Document, variations, fields);
+            var notification = new ContentIndexingNotification(indexInfo.IndexAlias, content.Key, UmbracoObjectTypes.Document, variations, fields);
             if (await _eventAggregator.PublishCancelableAsync(notification))
             {
                 // the indexing operation was cancelled for this index; continue with the rest of the indexes
@@ -228,14 +228,14 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         return true;
     }
 
-    private async Task RemoveFromIndexAsync(IndexInfo[] indexInfos, IReadOnlyCollection<ContentChange> contentChanges)
+    private async Task RemoveFromIndexAsync(ContentIndexInfo[] indexInfos, IReadOnlyCollection<ContentChange> contentChanges)
     {
         if (contentChanges.Count is 0)
         {
             return;
         }
 
-        foreach (IndexInfo indexInfo in indexInfos)
+        foreach (ContentIndexInfo indexInfo in indexInfos)
         {
             Guid[] keys = contentChanges
                 .Where(change => indexInfo.ContainedObjectTypes.Contains(change.ObjectType))
@@ -255,7 +255,7 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
         };
 
     private async Task RebuildAsync(
-        IndexInfo indexInfo,
+        ContentIndexInfo indexInfo,
         UmbracoObjectTypes objectType,
         Func<IEnumerable<IContentBase>> getContentAtRoot,
         Func<int, int, IEnumerable<IContentBase>> getPagedContentAtRecycleBinRoot,
@@ -272,7 +272,7 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
             return;
         }
 
-        IndexInfo[] indexInfos = [indexInfo];
+        ContentIndexInfo[] indexInfos = [indexInfo];
 
         foreach (IContentBase rootContent in getContentAtRoot())
         {

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IContentChangeStrategy.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IContentChangeStrategy.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
 
 public interface IContentChangeStrategy
 {
-    Task HandleAsync(IEnumerable<IndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken);
+    Task HandleAsync(IEnumerable<ContentIndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken);
 
-    Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken);
+    Task RebuildAsync(ContentIndexInfo indexInfo, CancellationToken cancellationToken);
 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/ServiceCollectionExtensions.cs
@@ -26,10 +26,10 @@ internal static class ServiceCollectionExtensions
 
         services.Configure<IndexOptions>(options =>
         {
-            options.RegisterIndex<IExamineIndexer, IExamineSearcher, IDraftContentChangeStrategy>(Core.Constants.IndexAliases.DraftContent, UmbracoObjectTypes.Document);
-            options.RegisterIndex<IExamineIndexer, IExamineSearcher, IPublishedContentChangeStrategy>(Core.Constants.IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
-            options.RegisterIndex<IExamineIndexer, IExamineSearcher, IDraftContentChangeStrategy>(Core.Constants.IndexAliases.DraftMedia, UmbracoObjectTypes.Media);
-            options.RegisterIndex<IExamineIndexer, IExamineSearcher, IDraftContentChangeStrategy>(Core.Constants.IndexAliases.DraftMembers, UmbracoObjectTypes.Member);
+            options.RegisterContentIndex<IExamineIndexer, IExamineSearcher, IDraftContentChangeStrategy>(Core.Constants.IndexAliases.DraftContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<IExamineIndexer, IExamineSearcher, IPublishedContentChangeStrategy>(Core.Constants.IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<IExamineIndexer, IExamineSearcher, IDraftContentChangeStrategy>(Core.Constants.IndexAliases.DraftMedia, UmbracoObjectTypes.Media);
+            options.RegisterContentIndex<IExamineIndexer, IExamineSearcher, IDraftContentChangeStrategy>(Core.Constants.IndexAliases.DraftMembers, UmbracoObjectTypes.Member);
         });
     }
 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/NotificationHandlers/RebuildNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/NotificationHandlers/RebuildNotificationHandler.cs
@@ -35,7 +35,7 @@ public class RebuildNotificationHandler : INotificationHandler<UmbracoApplicatio
     public void Handle(UmbracoApplicationStartedNotification notification)
     {
         _logger.LogInformation("Boot detected, determining indexes to rebuild");
-        foreach (IndexRegistration indexRegistration in _options.GetIndexRegistrations())
+        foreach (ContentIndexRegistration indexRegistration in _options.GetContentIndexRegistrations())
         {
             var activePhysicalName = _activeIndexManager.ResolveActiveIndexName(indexRegistration.IndexAlias);
 

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/ActiveIndexManager.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/ActiveIndexManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Examine;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Search.Core.Models.Configuration;
 using IndexOptions = Umbraco.Cms.Search.Core.Configuration.IndexOptions;
 
 namespace Umbraco.Cms.Search.Provider.Examine.Services;
@@ -18,7 +19,7 @@ internal sealed class ActiveIndexManager : IActiveIndexManager
     {
         _logger = logger;
 
-        foreach (var registration in indexOptions.Value.GetIndexRegistrations())
+        foreach (ContentIndexRegistration registration in indexOptions.Value.GetContentIndexRegistrations())
         {
             _indexes[registration.IndexAlias] = DetermineInitialSlot(registration.IndexAlias, examineManager);
         }

--- a/src/Umbraco.Test.Search.Integration/Services/TestIndexerAndSearcher.cs
+++ b/src/Umbraco.Test.Search.Integration/Services/TestIndexerAndSearcher.cs
@@ -13,7 +13,7 @@ using Constants = Umbraco.Cms.Search.Core.Constants;
 
 namespace Umbraco.Test.Search.Integration.Services;
 
-public class TestIndexer : IIndexer, ISearcher
+public class TestIndexerAndSearcher : IIndexer, ISearcher
 {
     private readonly Dictionary<string, Dictionary<Guid, TestIndexDocument>> _indexes = new();
 
@@ -80,7 +80,7 @@ public class TestIndexer : IIndexer, ISearcher
         {
             Constants.IndexAliases.DraftContent => TestBase.IndexAliases.DraftContent,
             Constants.IndexAliases.DraftMedia => TestBase.IndexAliases.Media,
-            _ => throw new ArgumentOutOfRangeException(nameof(indexAlias))
+            _ => indexAlias
         };
 
         bool IsVarianceMatch(IndexField field)

--- a/src/Umbraco.Test.Search.Integration/Tests/BlockGridPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BlockGridPropertyValueHandlerTests.cs
@@ -36,7 +36,7 @@ public class BlockGridPropertyValueHandlerTests : PropertyValueHandlerTestsBase
         await GetRequiredService<ILanguageService>()
             .CreateAsync(new Language("de-DE", "German (Germany)"), Constants.Security.SuperUserKey);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)
@@ -170,7 +170,7 @@ public class BlockGridPropertyValueHandlerTests : PropertyValueHandlerTestsBase
         AssertDocumentFields(IndexAliases.DraftContent);
         AssertDocumentFields(IndexAliases.PublishedContent);
 
-        TestIndexDocument document = Indexer.Dump(IndexAliases.PublishedContent).Single();
+        TestIndexDocument document = IndexerAndSearcher.Dump(IndexAliases.PublishedContent).Single();
         IndexValue? tagsValue = document.Fields.FirstOrDefault(f => f.FieldName == Cms.Search.Core.Constants.FieldNames.Tags)?.Value;
         Assert.That(tagsValue, Is.Not.Null);
         CollectionAssert.AreEquivalent(new [] { "One", "Two", "Three", "Four", "Five", "Six" }, tagsValue.Keywords);
@@ -179,7 +179,7 @@ public class BlockGridPropertyValueHandlerTests : PropertyValueHandlerTestsBase
 
         void AssertDocumentFields(string indexAlias)
         {
-            IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(indexAlias);
+            IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(indexAlias);
             Assert.That(documents, Has.Count.EqualTo(1));
 
             TestIndexDocument document = documents.Single();
@@ -304,7 +304,7 @@ public class BlockGridPropertyValueHandlerTests : PropertyValueHandlerTestsBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();

--- a/src/Umbraco.Test.Search.Integration/Tests/BlockListPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BlockListPropertyValueHandlerTests.cs
@@ -30,7 +30,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
         await GetRequiredService<ILanguageService>()
             .CreateAsync(new Language("de-DE", "German (Germany)"), Constants.Security.SuperUserKey);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)
@@ -164,7 +164,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
         AssertDocumentFields(IndexAliases.DraftContent);
         AssertDocumentFields(IndexAliases.PublishedContent);
 
-        TestIndexDocument document = Indexer.Dump(IndexAliases.PublishedContent).Single();
+        TestIndexDocument document = IndexerAndSearcher.Dump(IndexAliases.PublishedContent).Single();
         IndexValue? tagsValue = document.Fields.FirstOrDefault(f => f.FieldName == Cms.Search.Core.Constants.FieldNames.Tags)?.Value;
         Assert.That(tagsValue, Is.Not.Null);
         CollectionAssert.AreEquivalent(new [] { "One", "Two", "Three", "Four", "Five", "Six" }, tagsValue.Keywords);
@@ -173,7 +173,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
 
         void AssertDocumentFields(string indexAlias)
         {
-            IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(indexAlias);
+            IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(indexAlias);
             Assert.That(documents, Has.Count.EqualTo(1));
 
             TestIndexDocument document = documents.Single();
@@ -321,7 +321,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -353,7 +353,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
 
         void AssertDocumentFields(string indexAlias)
         {
-            IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(indexAlias);
+            IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(indexAlias);
             Assert.That(documents, Has.Count.EqualTo(1));
 
             TestIndexDocument document = documents.Single();
@@ -403,7 +403,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
 
         void AssertDocumentFields(string indexAlias, bool expectEnValues)
         {
-            IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(indexAlias);
+            IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(indexAlias);
             Assert.That(documents, Has.Count.EqualTo(1));
 
             TestIndexDocument document = documents.Single();
@@ -519,7 +519,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
 
         void AssertDocumentFields(string indexAlias, IEnumerable<string> expectedTextBoxValuesEn, IEnumerable<string> expectedTextBoxValuesDa)
         {
-            IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(indexAlias);
+            IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(indexAlias);
             Assert.That(documents, Has.Count.EqualTo(1));
 
             TestIndexDocument document = documents.Single();
@@ -600,7 +600,7 @@ public class BlockListPropertyValueHandlerTests : PropertyValueHandlerTestsBase
             .Build();
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         IndexValue? blocksValue = documents[0].Fields.FirstOrDefault(f => f.FieldName is "blocks")?.Value;

--- a/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingNotificationTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingNotificationTests.cs
@@ -7,12 +7,12 @@ using Umbraco.Test.Search.Integration.Services;
 
 namespace Umbraco.Test.Search.Integration.Tests;
 
-public class IndexingNotificationTests : InvariantContentTestBase
+public class ContentIndexingNotificationTests : InvariantContentTestBase
 {
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
         base.CustomTestSetup(builder);
-        builder.AddNotificationHandler<IndexingNotification, AddOrUpdateIndexingNotificationHandler>();
+        builder.AddNotificationHandler<ContentIndexingNotification, AddOrUpdateIndexingNotificationHandler>();
     }
 
     public override Task SetupTest()
@@ -28,7 +28,7 @@ public class IndexingNotificationTests : InvariantContentTestBase
         AddOrUpdateIndexingNotificationHandler.ManipulateFields = true;
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -54,7 +54,7 @@ public class IndexingNotificationTests : InvariantContentTestBase
         AddOrUpdateIndexingNotificationHandler.CancelIndexingFor = [ChildKey];
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -78,7 +78,7 @@ public class IndexingNotificationTests : InvariantContentTestBase
         AddOrUpdateIndexingNotificationHandler.ManipulateFields = true;
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -104,7 +104,7 @@ public class IndexingNotificationTests : InvariantContentTestBase
         AddOrUpdateIndexingNotificationHandler.CancelIndexingFor = [ChildKey];
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -145,13 +145,13 @@ public class IndexingNotificationTests : InvariantContentTestBase
         }
     }
 
-    private class AddOrUpdateIndexingNotificationHandler : INotificationHandler<IndexingNotification>
+    private class AddOrUpdateIndexingNotificationHandler : INotificationHandler<ContentIndexingNotification>
     {
         public static bool ManipulateFields { get; set; }
 
         public static Guid[] CancelIndexingFor { get; set; } = [];
 
-        public void Handle(IndexingNotification notification)
+        public void Handle(ContentIndexingNotification notification)
         {
             if (ManipulateFields)
             {

--- a/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingServiceExplicitIndexRegistrationsTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingServiceExplicitIndexRegistrationsTests.cs
@@ -14,13 +14,13 @@ public class ContentIndexingServiceExplicitIndexRegistrationsTests : ContentInde
     {
         base.CustomTestSetup(builder);
 
-        builder.Services.AddTransient<TestIndexer>();
+        builder.Services.AddTransient<TestIndexerAndSearcher>();
         builder.Services.AddTransient<TestContentChangeStrategy>(_ => Strategy);
 
         builder.Services.Configure<IndexOptions>(options =>
         {
-            options.RegisterIndex<TestIndexer, TestIndexer, TestContentChangeStrategy>(Constants.IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
-            options.RegisterIndex<TestIndexer, TestIndexer, TestContentChangeStrategy>(Constants.IndexAliases.DraftContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<TestIndexerAndSearcher, TestIndexerAndSearcher, TestContentChangeStrategy>(Constants.IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<TestIndexerAndSearcher, TestIndexerAndSearcher, TestContentChangeStrategy>(Constants.IndexAliases.DraftContent, UmbracoObjectTypes.Document);
         });
     }
 
@@ -38,10 +38,10 @@ public class ContentIndexingServiceExplicitIndexRegistrationsTests : ContentInde
         Assert.Multiple(() =>
         {
             Assert.That(Strategy.HandledIndexInfos[0][0].IndexAlias, Is.EqualTo(Constants.IndexAliases.PublishedContent));
-            Assert.That(Strategy.HandledIndexInfos[0][0].Indexer, Is.TypeOf<TestIndexer>());
+            Assert.That(Strategy.HandledIndexInfos[0][0].Indexer, Is.TypeOf<TestIndexerAndSearcher>());
 
             Assert.That(Strategy.HandledIndexInfos[0][1].IndexAlias, Is.EqualTo(Constants.IndexAliases.DraftContent));
-            Assert.That(Strategy.HandledIndexInfos[0][1].Indexer, Is.TypeOf<TestIndexer>());
+            Assert.That(Strategy.HandledIndexInfos[0][1].Indexer, Is.TypeOf<TestIndexerAndSearcher>());
         });
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingServiceImplicitIndexRegistrationsTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingServiceImplicitIndexRegistrationsTests.cs
@@ -15,15 +15,15 @@ public class ContentIndexingServiceImplicitIndexRegistrationsTests : ContentInde
     {
         base.CustomTestSetup(builder);
 
-        builder.Services.AddTransient<IIndexer, TestIndexer>();
-        builder.Services.AddTransient<ISearcher, TestIndexer>();
+        builder.Services.AddTransient<IIndexer, TestIndexerAndSearcher>();
+        builder.Services.AddTransient<ISearcher, TestIndexerAndSearcher>();
         builder.Services.AddTransient<IPublishedContentChangeStrategy>(_ => Strategy);
         builder.Services.AddTransient<IDraftContentChangeStrategy>(_ => Strategy);
 
         builder.Services.Configure<IndexOptions>(options =>
         {
-            options.RegisterIndex<IIndexer, ISearcher, IPublishedContentChangeStrategy>(Constants.IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
-            options.RegisterIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(Constants.IndexAliases.DraftContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<IIndexer, ISearcher, IPublishedContentChangeStrategy>(Constants.IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(Constants.IndexAliases.DraftContent, UmbracoObjectTypes.Document);
         });
     }
 
@@ -45,10 +45,10 @@ public class ContentIndexingServiceImplicitIndexRegistrationsTests : ContentInde
         Assert.Multiple(() =>
         {
             Assert.That(Strategy.HandledIndexInfos[0][0].IndexAlias, Is.EqualTo(Constants.IndexAliases.PublishedContent));
-            Assert.That(Strategy.HandledIndexInfos[0][0].Indexer, Is.TypeOf<TestIndexer>());
+            Assert.That(Strategy.HandledIndexInfos[0][0].Indexer, Is.TypeOf<TestIndexerAndSearcher>());
 
             Assert.That(Strategy.HandledIndexInfos[1][0].IndexAlias, Is.EqualTo(Constants.IndexAliases.DraftContent));
-            Assert.That(Strategy.HandledIndexInfos[1][0].Indexer, Is.TypeOf<TestIndexer>());
+            Assert.That(Strategy.HandledIndexInfos[1][0].Indexer, Is.TypeOf<TestIndexerAndSearcher>());
         });
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingServiceTestsBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ContentIndexingServiceTestsBase.cs
@@ -29,15 +29,15 @@ public abstract class ContentIndexingServiceTestsBase : UmbracoIntegrationTest
 
     protected class TestContentChangeStrategy : IPublishedContentChangeStrategy, IDraftContentChangeStrategy
     {
-        public Task HandleAsync(IEnumerable<IndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
+        public Task HandleAsync(IEnumerable<ContentIndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
         {
             HandledIndexInfos.Add(indexInfos.ToList());
             return Task.CompletedTask;
         }
 
-        public Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken)
+        public Task RebuildAsync(ContentIndexInfo indexInfo, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public List<List<IndexInfo>> HandledIndexInfos { get; } = new();
+        public List<List<ContentIndexInfo>> HandledIndexInfos { get; } = new();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/ContentTypeTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ContentTypeTests.cs
@@ -34,7 +34,7 @@ public class ContentTypeTests : ContentBaseTestBase
     [SetUp]
     public async Task SetupTest()
     {
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
 
         _contentType1 = await CreateContentType();
         _contentType2 = await CreateContentType();
@@ -79,18 +79,18 @@ public class ContentTypeTests : ContentBaseTestBase
     [Test]
     public async Task DeleteContentType1()
     {
-        IReadOnlyList<TestIndexDocument> draftDocuments = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> draftDocuments = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(draftDocuments, Has.Count.EqualTo(6));
 
-        IReadOnlyList<TestIndexDocument> publishedDocuments = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> publishedDocuments = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(publishedDocuments, Has.Count.EqualTo(6));
 
         await ContentTypeService.DeleteAsync(_contentType1.Key, Constants.Security.SuperUserKey);
 
-        draftDocuments = Indexer.Dump(IndexAliases.DraftContent);
+        draftDocuments = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(draftDocuments, Has.Count.EqualTo(4));
 
-        publishedDocuments = Indexer.Dump(IndexAliases.PublishedContent);
+        publishedDocuments = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(publishedDocuments, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -110,19 +110,19 @@ public class ContentTypeTests : ContentBaseTestBase
     [Test]
     public async Task DeleteContentType2And3()
     {
-        IReadOnlyList<TestIndexDocument> draftDocuments = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> draftDocuments = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(draftDocuments, Has.Count.EqualTo(6));
 
-        IReadOnlyList<TestIndexDocument> publishedDocuments = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> publishedDocuments = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(publishedDocuments, Has.Count.EqualTo(6));
 
         await ContentTypeService.DeleteAsync(_contentType2.Key, Constants.Security.SuperUserKey);
         await ContentTypeService.DeleteAsync(_contentType3.Key, Constants.Security.SuperUserKey);
 
-        draftDocuments = Indexer.Dump(IndexAliases.DraftContent);
+        draftDocuments = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(draftDocuments, Has.Count.EqualTo(2));
 
-        publishedDocuments = Indexer.Dump(IndexAliases.PublishedContent);
+        publishedDocuments = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(publishedDocuments, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>
@@ -138,20 +138,20 @@ public class ContentTypeTests : ContentBaseTestBase
     [Test]
     public async Task DeleteAllContentTypes()
     {
-        IReadOnlyList<TestIndexDocument> draftDocuments = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> draftDocuments = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(draftDocuments, Has.Count.EqualTo(6));
 
-        IReadOnlyList<TestIndexDocument> publishedDocuments = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> publishedDocuments = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(publishedDocuments, Has.Count.EqualTo(6));
 
         await ContentTypeService.DeleteAsync(_contentType1.Key, Constants.Security.SuperUserKey);
         await ContentTypeService.DeleteAsync(_contentType2.Key, Constants.Security.SuperUserKey);
         await ContentTypeService.DeleteAsync(_contentType3.Key, Constants.Security.SuperUserKey);
 
-        draftDocuments = Indexer.Dump(IndexAliases.DraftContent);
+        draftDocuments = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(draftDocuments, Is.Empty);
 
-        publishedDocuments = Indexer.Dump(IndexAliases.PublishedContent);
+        publishedDocuments = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(publishedDocuments, Is.Empty);
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/CustomContentIndexRegistrationTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/CustomContentIndexRegistrationTests.cs
@@ -1,0 +1,147 @@
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Search.Core.Configuration;
+using Umbraco.Cms.Search.Core.Services;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Test.Search.Integration.Services;
+using CoreConstants = Umbraco.Cms.Core.Constants;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+public class CustomContentIndexRegistrationTests : ContentBaseTestBase
+{
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IMediaService MediaService => GetRequiredService<IMediaService>();
+
+    private IMemberService MemberService => GetRequiredService<IMemberService>();
+
+    private Guid ContentKey { get; } = Guid.NewGuid();
+
+    private Guid MediaKey { get; } = Guid.NewGuid();
+
+    private Guid MemberKey { get; } = Guid.NewGuid();
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        base.CustomTestSetup(builder);
+
+        builder.Services.Configure<IndexOptions>(options =>
+        {
+            options.RegisterContentIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>("My_Index", UmbracoObjectTypes.Document, UmbracoObjectTypes.Media, UmbracoObjectTypes.Member);
+        });
+    }
+
+    [SetUp]
+    public async Task SetupTest()
+    {
+        IContentType contentType = new ContentTypeBuilder()
+            .WithAlias("theContentType")
+            .AddPropertyType()
+            .WithAlias("title")
+            .WithDataTypeId(CoreConstants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(CoreConstants.PropertyEditors.Aliases.TextBox)
+            .Done()
+            .Build();
+        await GetRequiredService<IContentTypeService>().CreateAsync(contentType, CoreConstants.Security.SuperUserKey);
+
+        ContentService.Save(
+            new ContentBuilder()
+                .WithKey(ContentKey)
+                .WithContentType(contentType)
+                .WithName("The Content")
+                .WithPropertyValues(
+                    new
+                    {
+                        title = "The content title"
+                    })
+                .Build());
+
+        IMediaType mediaType = new MediaTypeBuilder()
+            .WithAlias("theMediaType")
+            .AddPropertyGroup()
+            .AddPropertyType()
+            .WithAlias("altText")
+            .WithDataTypeId(CoreConstants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(CoreConstants.PropertyEditors.Aliases.TextBox)
+            .Done()
+            .Done()
+            .Build();
+        await GetRequiredService<IMediaTypeService>().CreateAsync(mediaType, CoreConstants.Security.SuperUserKey);
+
+        MediaService.Save(
+            new MediaBuilder()
+                .WithKey(MediaKey)
+                .WithMediaType(mediaType)
+                .WithName("The Media")
+                .WithPropertyValues(
+                    new
+                    {
+                        altText = "The media alt text"
+                    })
+                .Build());
+
+        IMemberType memberType = new MemberTypeBuilder()
+            .WithAlias("theMemberType")
+            .AddPropertyGroup()
+            .AddPropertyType()
+            .WithAlias("organization")
+            .WithDataTypeId(CoreConstants.DataTypes.Textbox)
+            .WithPropertyEditorAlias(CoreConstants.PropertyEditors.Aliases.TextBox)
+            .Done()
+            .Done()
+            .Build();
+        await GetRequiredService<IMemberTypeService>().CreateAsync(memberType, CoreConstants.Security.SuperUserKey);
+
+        MemberService.Save(
+            new MemberBuilder()
+                .WithKey(MemberKey)
+                .WithMemberType(memberType)
+                .WithName("The Member")
+                .WithEmail("member@local")
+                .WithLogin("member@local", "Test123456")
+                .AddPropertyData()
+                .WithKeyValue("organization", "The Organization")
+                .Done()
+                .Build());
+
+        IndexerAndSearcher.Reset();
+    }
+
+    [Test]
+    public void CustomIndexRegistration_CanContainAllTypesOfContent()
+    {
+        ContentService.Save(Content());
+        MediaService.Save(Media());
+        MemberService.Save(Member());
+
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump("My_Index");
+        Assert.That(documents, Has.Count.EqualTo(3));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(documents[0].Id, Is.EqualTo(ContentKey));
+            Assert.That(documents[0].ObjectType, Is.EqualTo(UmbracoObjectTypes.Document));
+            Assert.That(documents[1].Id, Is.EqualTo(MediaKey));
+            Assert.That(documents[1].ObjectType, Is.EqualTo(UmbracoObjectTypes.Media));
+            Assert.That(documents[2].Id, Is.EqualTo(MemberKey));
+            Assert.That(documents[2].ObjectType, Is.EqualTo(UmbracoObjectTypes.Member));
+        });
+
+        Assert.Multiple(() =>
+        {
+            VerifyDocumentSystemValues(documents[0], Content(), []);
+            VerifyDocumentSystemValues(documents[1], Media(), []);
+            VerifyDocumentSystemValues(documents[2], Member(), []);
+        });
+    }
+
+    private IContent Content() => ContentService.GetById(ContentKey) ?? throw new InvalidOperationException("Content was not found");
+
+    private IMedia Media() => MediaService.GetById(MediaKey) ?? throw new InvalidOperationException("Media was not found");
+
+    private IMember Member() => MemberService.GetById(MemberKey) ?? throw new InvalidOperationException("Member was not found");
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/CustomIndexDataTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/CustomIndexDataTests.cs
@@ -36,7 +36,7 @@ public class CustomIndexDataTests : TestBase
             ],
             protection: null);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump("My_Data");
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump("My_Data");
 
         Assert.That(documents.Count, Is.EqualTo(1));
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/CustomIndexRegistrationTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/CustomIndexRegistrationTests.cs
@@ -1,29 +1,24 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Search.Core.Configuration;
+using Umbraco.Cms.Search.Core.Extensions;
+using Umbraco.Cms.Search.Core.Models.Configuration;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Models.Searching;
 using Umbraco.Cms.Search.Core.Services;
-using Umbraco.Cms.Search.Core.Services.ContentIndexing;
-using Umbraco.Cms.Tests.Common.Builders;
-using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Test.Search.Integration.Services;
-using CoreConstants = Umbraco.Cms.Core.Constants;
 
 namespace Umbraco.Test.Search.Integration.Tests;
 
-public class CustomIndexRegistrationTests : ContentBaseTestBase
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class CustomIndexRegistrationTests : TestBase
 {
-    private IContentService ContentService => GetRequiredService<IContentService>();
+    private const string IndexAlias = "My_Index";
 
-    private IMediaService MediaService => GetRequiredService<IMediaService>();
-
-    private IMemberService MemberService => GetRequiredService<IMemberService>();
-
-    private Guid ContentKey { get; } = Guid.NewGuid();
-
-    private Guid MediaKey { get; } = Guid.NewGuid();
-
-    private Guid MemberKey { get; } = Guid.NewGuid();
+    private IndexOptions IndexOptions => GetRequiredService<IOptions<IndexOptions>>().Value;
 
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
@@ -31,117 +26,61 @@ public class CustomIndexRegistrationTests : ContentBaseTestBase
 
         builder.Services.Configure<IndexOptions>(options =>
         {
-            options.RegisterIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>("My_Index", UmbracoObjectTypes.Document, UmbracoObjectTypes.Media, UmbracoObjectTypes.Member);
+            options.RegisterIndex<IIndexer, ISearcher>(IndexAlias);
         });
-    }
-
-    [SetUp]
-    public async Task SetupTest()
-    {
-        IContentType contentType = new ContentTypeBuilder()
-            .WithAlias("theContentType")
-            .AddPropertyType()
-            .WithAlias("title")
-            .WithDataTypeId(CoreConstants.DataTypes.Textbox)
-            .WithPropertyEditorAlias(CoreConstants.PropertyEditors.Aliases.TextBox)
-            .Done()
-            .Build();
-        await GetRequiredService<IContentTypeService>().CreateAsync(contentType, CoreConstants.Security.SuperUserKey);
-
-        ContentService.Save(
-            new ContentBuilder()
-                .WithKey(ContentKey)
-                .WithContentType(contentType)
-                .WithName("The Content")
-                .WithPropertyValues(
-                    new
-                    {
-                        title = "The content title"
-                    })
-                .Build());
-
-        IMediaType mediaType = new MediaTypeBuilder()
-            .WithAlias("theMediaType")
-            .AddPropertyGroup()
-            .AddPropertyType()
-            .WithAlias("altText")
-            .WithDataTypeId(CoreConstants.DataTypes.Textbox)
-            .WithPropertyEditorAlias(CoreConstants.PropertyEditors.Aliases.TextBox)
-            .Done()
-            .Done()
-            .Build();
-        await GetRequiredService<IMediaTypeService>().CreateAsync(mediaType, CoreConstants.Security.SuperUserKey);
-
-        MediaService.Save(
-            new MediaBuilder()
-                .WithKey(MediaKey)
-                .WithMediaType(mediaType)
-                .WithName("The Media")
-                .WithPropertyValues(
-                    new
-                    {
-                        altText = "The media alt text"
-                    })
-                .Build());
-
-        IMemberType memberType = new MemberTypeBuilder()
-            .WithAlias("theMemberType")
-            .AddPropertyGroup()
-            .AddPropertyType()
-            .WithAlias("organization")
-            .WithDataTypeId(CoreConstants.DataTypes.Textbox)
-            .WithPropertyEditorAlias(CoreConstants.PropertyEditors.Aliases.TextBox)
-            .Done()
-            .Done()
-            .Build();
-        await GetRequiredService<IMemberTypeService>().CreateAsync(memberType, CoreConstants.Security.SuperUserKey);
-
-        MemberService.Save(
-            new MemberBuilder()
-                .WithKey(MemberKey)
-                .WithMemberType(memberType)
-                .WithName("The Member")
-                .WithEmail("member@local")
-                .WithLogin("member@local", "Test123456")
-                .AddPropertyData()
-                .WithKeyValue("organization", "The Organization")
-                .Done()
-                .Build());
-
-        Indexer.Reset();
     }
 
     [Test]
-    public void CustomIndexRegistration_CanContainAllTypesOfContent()
+    public void Can_Get_Index_Registration()
     {
-        ContentService.Save(Content());
-        MediaService.Save(Media());
-        MemberService.Save(Member());
-
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump("My_Index");
-        Assert.That(documents, Has.Count.EqualTo(3));
+        IndexRegistration? indexRegistration = IndexOptions.GetIndexRegistration(IndexAlias);
+        Assert.That(indexRegistration, Is.Not.Null);
 
         Assert.Multiple(() =>
         {
-            Assert.That(documents[0].Id, Is.EqualTo(ContentKey));
-            Assert.That(documents[0].ObjectType, Is.EqualTo(UmbracoObjectTypes.Document));
-            Assert.That(documents[1].Id, Is.EqualTo(MediaKey));
-            Assert.That(documents[1].ObjectType, Is.EqualTo(UmbracoObjectTypes.Media));
-            Assert.That(documents[2].Id, Is.EqualTo(MemberKey));
-            Assert.That(documents[2].ObjectType, Is.EqualTo(UmbracoObjectTypes.Member));
-        });
-
-        Assert.Multiple(() =>
-        {
-            VerifyDocumentSystemValues(documents[0], Content(), []);
-            VerifyDocumentSystemValues(documents[1], Media(), []);
-            VerifyDocumentSystemValues(documents[2], Member(), []);
+            Assert.That(indexRegistration.IndexAlias, Is.EqualTo(IndexAlias));
+            Assert.That(indexRegistration.Indexer, Is.EqualTo(typeof(IIndexer)));
+            Assert.That(indexRegistration.Searcher, Is.EqualTo(typeof(ISearcher)));
         });
     }
 
-    private IContent Content() => ContentService.GetById(ContentKey) ?? throw new InvalidOperationException("Content was not found");
+    [Test]
+    public void Can_Resolve_Required_Searcher()
+    {
+        ISearcherResolver searcherResolver = GetRequiredService<ISearcherResolver>();
+        Assert.That(searcherResolver.GetRequiredSearcher(IndexAlias), Is.TypeOf<TestIndexerAndSearcher>());
+    }
 
-    private IMedia Media() => MediaService.GetById(MediaKey) ?? throw new InvalidOperationException("Media was not found");
+    [Test]
+    public async Task Can_Populate_Custom_Index()
+    {
+        IIndexer indexer = GetRequiredService<IIndexer>();
+        var id = Guid.NewGuid();
+        await indexer.AddOrUpdateAsync(
+            IndexAlias,
+            id,
+            UmbracoObjectTypes.Unknown,
+            variations: [new Variation(null, null)],
+            fields:
+            [
+                new IndexField("FieldOne", new() { Texts = ["This is field one"] }, null, null),
+                new IndexField("FieldTwo", new() { Integers = [222] }, null, null),
+            ],
+            protection: null);
 
-    private IMember Member() => MemberService.GetById(MemberKey) ?? throw new InvalidOperationException("Member was not found");
+        ISearcher searcher = GetRequiredService<ISearcher>();
+        SearchResult searchResult = await searcher.SearchAsync(IndexAlias, take: 10);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResult.Total, Is.EqualTo(1));
+            Assert.That(searchResult.Documents.Count(), Is.EqualTo(1));
+        });
+
+        Assert.That(searchResult.Documents.First().Id, Is.EqualTo(id));
+    }
+
+    [Test]
+    public void Cannot_Get_Index_Registration_As_Content_Index_Registration()
+        => Assert.That(IndexOptions.GetContentIndexRegistration("My_Index"), Is.Null);
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/InvariantContentStructureTests.Draft.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/InvariantContentStructureTests.Draft.cs
@@ -11,7 +11,7 @@ public partial class InvariantContentStructureTests
     {
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -30,7 +30,7 @@ public partial class InvariantContentStructureTests
     {
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(0));
     }
 
@@ -39,7 +39,7 @@ public partial class InvariantContentStructureTests
     {
         ContentService.Save(Root());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
     }
@@ -57,7 +57,7 @@ public partial class InvariantContentStructureTests
             Assert.That(GreatGrandchild().Trashed, Is.True);
         });
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -81,7 +81,7 @@ public partial class InvariantContentStructureTests
             Assert.That(ContentService.GetById(GreatGrandchildKey), Is.Null);
         });
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/InvariantContentStructureTests.Published.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/InvariantContentStructureTests.Published.cs
@@ -12,7 +12,7 @@ public partial class InvariantContentStructureTests
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -32,7 +32,7 @@ public partial class InvariantContentStructureTests
         ContentService.Save(Root());
         ContentService.Publish(Root(), ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
     }
@@ -47,7 +47,7 @@ public partial class InvariantContentStructureTests
         Assert.That(result.Success, Is.True);
         Assert.That(Child().Published, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Is.Empty);
     }
 
@@ -61,7 +61,7 @@ public partial class InvariantContentStructureTests
         Assert.That(result.Success, Is.True);
         Assert.That(GreatGrandchild().Published, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>
@@ -81,7 +81,7 @@ public partial class InvariantContentStructureTests
         Assert.That(result.Success, Is.True);
         Assert.That(GreatGrandchild().Trashed, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>
@@ -104,7 +104,7 @@ public partial class InvariantContentStructureTests
             Assert.That(ContentService.GetById(GreatGrandchildKey), Is.Null);
         });
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTestBase.cs
@@ -91,6 +91,6 @@ public abstract class InvariantContentTestBase : ContentTestBase
             .Build();
         ContentService.Save(greatGrandchild);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTests.Draft.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTests.Draft.cs
@@ -15,7 +15,7 @@ public partial class InvariantContentTests
         SetupDraftContent();
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -41,7 +41,7 @@ public partial class InvariantContentTests
         SetupDraftContent();
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -67,7 +67,7 @@ public partial class InvariantContentTests
         SetupDraftContent();
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -97,7 +97,7 @@ public partial class InvariantContentTests
         SetupDraftContent();
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -126,7 +126,7 @@ public partial class InvariantContentTests
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
         ContentService.MoveToRecycleBin(Root());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -154,7 +154,7 @@ public partial class InvariantContentTests
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
         ContentService.MoveToRecycleBin(Root());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -182,7 +182,7 @@ public partial class InvariantContentTests
         ContentService.Save([Root(), Child(), Grandchild(), GreatGrandchild()]);
         ContentService.MoveToRecycleBin(Child());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -222,7 +222,7 @@ public partial class InvariantContentTests
         OperationResult moveResult = ContentService.Move(Root(), secondRoot.Id);
         Assert.That(moveResult.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -263,7 +263,7 @@ public partial class InvariantContentTests
         OperationResult moveResult = ContentService.Move(Child(), secondRoot.Id);
         Assert.That(moveResult.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -302,7 +302,7 @@ public partial class InvariantContentTests
 
         ContentService.Delete(Root());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(0));
     }
 
@@ -320,7 +320,7 @@ public partial class InvariantContentTests
 
         ContentService.Delete(Child());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
         VerifyDocumentStructureValues(documents[0], RootKey, Guid.Empty, [RootKey]);
@@ -338,7 +338,7 @@ public partial class InvariantContentTests
 
         ContentIndexingService.Rebuild(IndexAliases.DraftContent);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -372,7 +372,7 @@ public partial class InvariantContentTests
 
         ContentIndexingService.Rebuild(IndexAliases.DraftContent);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTests.Published.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTests.Published.cs
@@ -14,7 +14,7 @@ public partial class InvariantContentTests
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -46,7 +46,7 @@ public partial class InvariantContentTests
         ContentService.Save(child);
         ContentService.Publish(child, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -66,7 +66,7 @@ public partial class InvariantContentTests
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -92,7 +92,7 @@ public partial class InvariantContentTests
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -124,7 +124,7 @@ public partial class InvariantContentTests
         ContentService.Save(child);
         ContentService.Publish(child, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.That(documents[1].Id, Is.EqualTo(ChildKey));
@@ -138,7 +138,7 @@ public partial class InvariantContentTests
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
         ContentService.MoveToRecycleBin(Root());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(0));
     }
 
@@ -149,7 +149,7 @@ public partial class InvariantContentTests
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
         ContentService.MoveToRecycleBin(Child());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
     }
@@ -171,7 +171,7 @@ public partial class InvariantContentTests
         OperationResult moveResult = ContentService.Move(Root(), secondRoot.Id);
         Assert.That(moveResult.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -212,7 +212,7 @@ public partial class InvariantContentTests
         OperationResult moveResult = ContentService.Move(Child(), secondRoot.Id);
         Assert.That(moveResult.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -253,7 +253,7 @@ public partial class InvariantContentTests
         OperationResult moveResult = ContentService.Move(Child(), secondRoot.Id);
         Assert.That(moveResult.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
 
@@ -266,7 +266,7 @@ public partial class InvariantContentTests
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
         ContentIndexingService.Rebuild(IndexAliases.PublishedContent);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -300,7 +300,7 @@ public partial class InvariantContentTests
 
         ContentIndexingService.Rebuild(IndexAliases.PublishedContent);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
         VerifyDocumentStructureValues(documents[0], RootKey, Guid.Empty, [RootKey]);

--- a/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/InvariantContentTests.cs
@@ -18,7 +18,7 @@ public partial class InvariantContentTests : InvariantContentTestBase
             ContentService.Save(content);
         }
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 
     private void VerifyDocumentPropertyValues(TestIndexDocument document, string title, int count)

--- a/src/Umbraco.Test.Search.Integration/Tests/LabelPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/LabelPropertyValueHandlerTests.cs
@@ -31,7 +31,7 @@ public class LabelPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -74,7 +74,7 @@ public class LabelPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -103,7 +103,7 @@ public class LabelPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -157,6 +157,6 @@ public class LabelPropertyValueHandlerTests : ContentTestBase
 
         await ContentTypeService.CreateAsync(_contentType, Constants.Security.SuperUserKey);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/MarkdownPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MarkdownPropertyValueHandlerTests.cs
@@ -50,7 +50,7 @@ public class MarkdownPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -87,7 +87,7 @@ public class MarkdownPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -112,7 +112,7 @@ public class MarkdownPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -136,7 +136,7 @@ public class MarkdownPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
 
@@ -170,6 +170,6 @@ public class MarkdownPropertyValueHandlerTests : ContentTestBase
 
         await ContentTypeService.CreateAsync(_contentType, Constants.Security.SuperUserKey);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/MediaContentTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MediaContentTests.cs
@@ -17,7 +17,7 @@ public class MediaContentTests : MediaTestBase
     {
         MediaService.Save([RootFolder(), ChildFolder(), RootMedia(), ChildMedia(), GrandchildMedia()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -35,7 +35,7 @@ public class MediaContentTests : MediaTestBase
     {
         MediaService.Save([RootFolder(), ChildFolder(), RootMedia(), ChildMedia(), GrandchildMedia()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -53,7 +53,7 @@ public class MediaContentTests : MediaTestBase
     {
         MediaService.Save([RootFolder(), ChildFolder(), RootMedia(), ChildMedia(), GrandchildMedia()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -84,7 +84,7 @@ public class MediaContentTests : MediaTestBase
         moveResult = MediaService.Move(ChildMedia(), secondRootFolder.Id);
         Assert.That(moveResult.Result?.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(6));
 
         Assert.Multiple(() =>
@@ -119,7 +119,7 @@ public class MediaContentTests : MediaTestBase
         moveResult = MediaService.Move(RootMedia(), secondRootFolder.Id);
         Assert.That(moveResult.Result?.Result, Is.EqualTo(OperationResultType.Success));
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(6));
 
         Assert.Multiple(() =>
@@ -142,7 +142,7 @@ public class MediaContentTests : MediaTestBase
         MediaService.MoveToRecycleBin(RootFolder());
         MediaService.MoveToRecycleBin(RootMedia());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -162,7 +162,7 @@ public class MediaContentTests : MediaTestBase
         MediaService.MoveToRecycleBin(RootFolder());
         MediaService.MoveToRecycleBin(RootMedia());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -183,7 +183,7 @@ public class MediaContentTests : MediaTestBase
         MediaService.MoveToRecycleBin(ChildFolder());
         MediaService.MoveToRecycleBin(ChildMedia());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -212,7 +212,7 @@ public class MediaContentTests : MediaTestBase
 
         MediaService.Delete(RootFolder());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         Assert.Multiple(() =>
@@ -235,7 +235,7 @@ public class MediaContentTests : MediaTestBase
 
         MediaService.Delete(ChildFolder());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -258,7 +258,7 @@ public class MediaContentTests : MediaTestBase
 
         ContentIndexingService.Rebuild(IndexAliases.Media);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -294,7 +294,7 @@ public class MediaContentTests : MediaTestBase
 
         ContentIndexingService.Rebuild(IndexAliases.Media);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/MediaStructureTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MediaStructureTests.cs
@@ -12,7 +12,7 @@ public class MediaStructureTests : MediaTestBase
     {
         MediaService.Save([RootFolder(), ChildFolder(), RootMedia(), ChildMedia(), GrandchildMedia()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -32,7 +32,7 @@ public class MediaStructureTests : MediaTestBase
     {
         MediaService.Save([RootFolder(), ChildFolder(), RootMedia(), ChildMedia(), GrandchildMedia()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(0));
     }
 
@@ -41,7 +41,7 @@ public class MediaStructureTests : MediaTestBase
     {
         MediaService.Save(RootFolder());
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootFolderKey));
     }
@@ -59,7 +59,7 @@ public class MediaStructureTests : MediaTestBase
             Assert.That(GrandchildMedia().Trashed, Is.True);
         });
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         Assert.Multiple(() =>
@@ -84,7 +84,7 @@ public class MediaStructureTests : MediaTestBase
             Assert.That(MediaService.GetById(GrandchildMediaKey), Is.Null);
         });
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -100,12 +100,12 @@ public class MediaStructureTests : MediaTestBase
     {
         MediaService.Save([RootFolder(), ChildFolder(), RootMedia(), ChildMedia(), GrandchildMedia()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Media);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(5));
 
         await MediaTypeService.DeleteAsync(RootMedia().ContentType.Key, Constants.Security.SuperUserKey);
 
-        documents = Indexer.Dump(IndexAliases.Media);
+        documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/MediaTestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MediaTestBase.cs
@@ -121,6 +121,6 @@ public abstract class MediaTestBase : ContentBaseTestBase
             .Build();
         MediaService.Save(grandchildMedia);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/MemberTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MemberTests.cs
@@ -17,7 +17,7 @@ public class MemberTests : ContentBaseTestBase
     {
         MemberService.Save([MemberOne(), MemberTwo(), MemberThree()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -35,7 +35,7 @@ public class MemberTests : ContentBaseTestBase
     {
         MemberService.Save([MemberOne(), MemberTwo(), MemberThree()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -51,7 +51,7 @@ public class MemberTests : ContentBaseTestBase
     {
         MemberService.Save([MemberOne(), MemberTwo(), MemberThree()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -67,7 +67,7 @@ public class MemberTests : ContentBaseTestBase
     {
         MemberService.Save([MemberOne(), MemberTwo(), MemberThree()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -90,7 +90,7 @@ public class MemberTests : ContentBaseTestBase
 
         MemberService.Save([MemberOne(), MemberTwo(), MemberThree()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -112,7 +112,7 @@ public class MemberTests : ContentBaseTestBase
 
         ContentIndexingService.Rebuild(IndexAliases.Member);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         Assert.Multiple(() =>
@@ -137,12 +137,12 @@ public class MemberTests : ContentBaseTestBase
     {
         MemberService.Save([MemberOne(), MemberTwo(), MemberThree()]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.Member);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
         Assert.That(documents, Has.Count.EqualTo(3));
 
         await MemberTypeService.DeleteAsync(MemberOne().ContentType.Key, Constants.Security.SuperUserKey);
 
-        documents = Indexer.Dump(IndexAliases.Media);
+        documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(0));
     }
 
@@ -222,7 +222,7 @@ public class MemberTests : ContentBaseTestBase
                 .Done()
                 .Build());
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 
     private void VerifyDocumentPropertyValues(TestIndexDocument document, string? organization)

--- a/src/Umbraco.Test.Search.Integration/Tests/MultiNodeTreePickerPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MultiNodeTreePickerPropertyValueHandlerTests.cs
@@ -30,7 +30,7 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -54,7 +54,7 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -79,7 +79,7 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -105,7 +105,7 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -215,6 +215,6 @@ public class MultiNodeTreePickerPropertyValueHandlerTests : ContentTestBase
 
         await ContentTypeService.CreateAsync(_contentType, Constants.Security.SuperUserKey);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/NoopPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/NoopPropertyValueHandlerTests.cs
@@ -45,7 +45,7 @@ public class NoopPropertyValueHandlerTests : ContentTestBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();

--- a/src/Umbraco.Test.Search.Integration/Tests/ProtectedContentTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ProtectedContentTests.cs
@@ -55,7 +55,7 @@ public class ProtectedContentTests : InvariantContentTestBase
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -89,7 +89,7 @@ public class ProtectedContentTests : InvariantContentTestBase
             ]));
         Assert.That(entryResult.Success, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -129,7 +129,7 @@ public class ProtectedContentTests : InvariantContentTestBase
         entryResult = PublicAccessService.Delete(entry);
         Assert.That(entryResult.Success, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/RichTextPropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/RichTextPropertyValueHandlerTests.cs
@@ -39,7 +39,7 @@ public class RichTextPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -74,7 +74,7 @@ public class RichTextPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -99,7 +99,7 @@ public class RichTextPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -123,7 +123,7 @@ public class RichTextPropertyValueHandlerTests : ContentTestBase
 
         ContentService.Save(content);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.DraftContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();
@@ -156,6 +156,6 @@ public class RichTextPropertyValueHandlerTests : ContentTestBase
 
         await ContentTypeService.CreateAsync(_contentType, Constants.Security.SuperUserKey);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/SearcherResolverTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/SearcherResolverTests.cs
@@ -9,7 +9,6 @@ using Umbraco.Cms.Search.Core.Models.Searching;
 using Umbraco.Cms.Search.Core.Models.Searching.Faceting;
 using Umbraco.Cms.Search.Core.Models.Searching.Filtering;
 using Umbraco.Cms.Search.Core.Models.Searching.Sorting;
-using Umbraco.Cms.Search.Core.Models.ViewModels;
 using Umbraco.Cms.Search.Core.Services;
 using Umbraco.Cms.Search.Core.Services.ContentIndexing;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -35,9 +34,9 @@ public class SearcherResolverTests : UmbracoIntegrationTest
 
         builder.Services.Configure<IndexOptions>(options =>
         {
-            options.RegisterIndex<TestIndexer, FirstSearcher, TestContentChangeStrategy>("FirstIndex", UmbracoObjectTypes.Document);
-            options.RegisterIndex<TestIndexer, SecondSearcher, TestContentChangeStrategy>("SecondIndex", UmbracoObjectTypes.Document);
-            options.RegisterIndex<TestIndexer, UnregisteredSearcher, TestContentChangeStrategy>("IndexWithUnregisteredSearcher", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<TestIndexer, FirstSearcher, TestContentChangeStrategy>("FirstIndex", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<TestIndexer, SecondSearcher, TestContentChangeStrategy>("SecondIndex", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<TestIndexer, UnregisteredSearcher, TestContentChangeStrategy>("IndexWithUnregisteredSearcher", UmbracoObjectTypes.Document);
         });
 
         _loggerMock = new Mock<ILogger<SearcherResolver>>();
@@ -99,10 +98,10 @@ public class SearcherResolverTests : UmbracoIntegrationTest
 
     private class TestContentChangeStrategy : IContentChangeStrategy
     {
-        public Task HandleAsync(IEnumerable<IndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
+        public Task HandleAsync(IEnumerable<ContentIndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task RebuildAsync(IndexInfo indexInfo, CancellationToken cancellationToken)
+        public Task RebuildAsync(ContentIndexInfo indexInfo, CancellationToken cancellationToken)
             => throw new NotImplementedException();
     }
 

--- a/src/Umbraco.Test.Search.Integration/Tests/SimplePropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/SimplePropertyValueHandlerTests.cs
@@ -63,7 +63,7 @@ public class SimplePropertyValueHandlerTests : PropertyValueHandlerTestsBase
         ContentService.Save(content);
         ContentService.Publish(content, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
 
         TestIndexDocument document = documents.Single();

--- a/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
@@ -26,7 +26,7 @@ public abstract class TestBase : UmbracoIntegrationTest
         public const string Member = "TestMemberIndex";
     }
 
-    protected TestIndexer Indexer { get; } = new();
+    protected TestIndexerAndSearcher IndexerAndSearcher { get; } = new();
 
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
@@ -39,15 +39,15 @@ public abstract class TestBase : UmbracoIntegrationTest
         builder.Services.AddUnique<IServerEventRouter, NoOpServerEventRouter>();
         builder.Services.AddUnique<IIndexDocumentRepository, NoopIndexDocumentRepository>();
 
-        builder.Services.AddTransient<IIndexer>(_ => Indexer);
-        builder.Services.AddTransient<ISearcher>(_ => Indexer);
+        builder.Services.AddTransient<IIndexer>(_ => IndexerAndSearcher);
+        builder.Services.AddTransient<ISearcher>(_ => IndexerAndSearcher);
 
         builder.Services.Configure<IndexOptions>(options =>
         {
-            options.RegisterIndex<IIndexer, ISearcher, IPublishedContentChangeStrategy>(IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
-            options.RegisterIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(IndexAliases.DraftContent, UmbracoObjectTypes.Document);
-            options.RegisterIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(IndexAliases.Media, UmbracoObjectTypes.Media);
-            options.RegisterIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(IndexAliases.Member, UmbracoObjectTypes.Member);
+            options.RegisterContentIndex<IIndexer, ISearcher, IPublishedContentChangeStrategy>(IndexAliases.PublishedContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(IndexAliases.DraftContent, UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(IndexAliases.Media, UmbracoObjectTypes.Media);
+            options.RegisterContentIndex<IIndexer, ISearcher, IDraftContentChangeStrategy>(IndexAliases.Member, UmbracoObjectTypes.Member);
         });
 
         builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();

--- a/src/Umbraco.Test.Search.Integration/Tests/VariantContentStructureTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/VariantContentStructureTests.cs
@@ -13,7 +13,7 @@ public class VariantContentStructureTests : VariantContentTestBase
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -42,7 +42,7 @@ public class VariantContentStructureTests : VariantContentTestBase
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, [culture]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -68,7 +68,7 @@ public class VariantContentStructureTests : VariantContentTestBase
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.Default, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(1));
         Assert.That(documents[0].Id, Is.EqualTo(RootKey));
         VerifyDocumentVariance(documents[0], "en-US", "da-DK");
@@ -84,7 +84,7 @@ public class VariantContentStructureTests : VariantContentTestBase
         Assert.That(result.Success, Is.True);
         Assert.That(Child().Published, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Is.Empty);
     }
 
@@ -107,7 +107,7 @@ public class VariantContentStructureTests : VariantContentTestBase
                 Is.EquivalentTo(new [] { expectedCulture.ToLowerInvariant() }));
         });
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -137,7 +137,7 @@ public class VariantContentStructureTests : VariantContentTestBase
         Assert.That(result.Success, Is.True);
         Assert.That(GreatGrandchild().Published, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>
@@ -167,7 +167,7 @@ public class VariantContentStructureTests : VariantContentTestBase
         Assert.That(Grandchild().Published, Is.False);
         Assert.That(GreatGrandchild().Published, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(2));
 
         Assert.Multiple(() =>
@@ -205,7 +205,7 @@ public class VariantContentStructureTests : VariantContentTestBase
 
         Assert.That(GreatGrandchild().Published, Is.True);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>

--- a/src/Umbraco.Test.Search.Integration/Tests/VariantContentTestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/VariantContentTestBase.cs
@@ -88,7 +88,7 @@ public abstract class VariantContentTestBase : ContentTestBase
         greatGrandchild.SetValue("count", 78);
         ContentService.Save(greatGrandchild);
 
-        Indexer.Reset();
+        IndexerAndSearcher.Reset();
     }
 
     private void SetTitle(IContent content, string title)

--- a/src/Umbraco.Test.Search.Integration/Tests/VariantContentTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/VariantContentTests.cs
@@ -15,7 +15,7 @@ public class VariantContentTests : VariantContentTestBase
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>
@@ -49,7 +49,7 @@ public class VariantContentTests : VariantContentTestBase
         ContentService.Save(child);
         ContentService.Publish(Child(), ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         VerifyDocumentPropertyValues(
@@ -73,7 +73,7 @@ public class VariantContentTests : VariantContentTestBase
         ContentService.Save(child);
         ContentService.Publish(Child(), ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         VerifyDocumentPropertyValues(documents[1], "The updated child title", "The child message", 34);
@@ -90,7 +90,7 @@ public class VariantContentTests : VariantContentTestBase
         ContentService.Save(child);
         ContentService.Publish(Child(), ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         VerifyDocumentPropertyValues(documents[1], "The child title", "The child message", 123456);
@@ -102,7 +102,7 @@ public class VariantContentTests : VariantContentTestBase
         ContentService.Save(Root());
         ContentService.PublishBranch(Root(), PublishBranchFilter.IncludeUnpublished, ["*"]);
 
-        IReadOnlyList<TestIndexDocument> documents = Indexer.Dump(IndexAliases.PublishedContent);
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
         Assert.That(documents, Has.Count.EqualTo(4));
 
         Assert.Multiple(() =>


### PR DESCRIPTION
This is an alternative to https://github.com/umbraco/Umbraco.Cms.Search/pull/81

We would like to be able to "just" register an index by alias, without having to consider object types and change strategies.

This PR changes the `RegisterIndex` method on `IndexOptions` to do just that, and moves content related index registrations to a new `RegisterContentIndex` method instead.

In most cases, it is not strictly necessary to register a custom index on `IndexOptions`. However, if one starts utilizing multiple search providers, one might like to re-register indexes to target specific providers, and this is only possible for registered indexes.

See `CustomIndexRegistrationTests` for an example of registering a custom index with `RegisterIndex`, and `CustomContentIndexRegistrationTests` for an example of registering a custom _content_ index 😄 