### PR TITLE
Add an indexer resolver

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Controllers/ApiControllerBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/ApiControllerBase.cs
@@ -1,9 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Api.Common.Attributes;
-using Umbraco.Cms.Search.Core.Services;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Cms.Web.Common.Routing;
 
@@ -16,17 +13,4 @@ namespace Umbraco.Cms.Search.Core.Controllers;
 [ApiExplorerSettings(GroupName = "Search")]
 public abstract class ApiControllerBase : ControllerBase
 {
-    // TODO: replace this with an IIndexerResolver service (like the ISearcherResolver)
-    internal static bool TryGetIndexer(IServiceProvider serviceProvider, Type type, ILogger logger, [NotNullWhen(true)] out IIndexer? indexer)
-    {
-        if (serviceProvider.GetService(type) is IIndexer resolvedIndexer)
-        {
-            indexer = resolvedIndexer;
-            return true;
-        }
-
-        logger.LogError($"Could not resolve type {{type}} as {nameof(IIndexer)}. Make sure the type is registered in the DI.", type.FullName);
-        indexer = null;
-        return false;
-    }
 }

--- a/src/Umbraco.Cms.Search.Core/Controllers/GetAllIndexesApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/GetAllIndexesApiController.cs
@@ -1,7 +1,6 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Search.Core.Configuration;
@@ -15,17 +14,12 @@ namespace Umbraco.Cms.Search.Core.Controllers;
 [ApiVersion("1.0")]
 public class GetAllIndexesApiController : ApiControllerBase
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<GetAllIndexesApiController> _logger;
+    private readonly IIndexerResolver _indexerResolver;
     private readonly IndexOptions _options;
 
-    public GetAllIndexesApiController(
-        IOptions<IndexOptions> options,
-        IServiceProvider serviceProvider,
-        ILogger<GetAllIndexesApiController> logger)
+    public GetAllIndexesApiController(IIndexerResolver indexerResolver, IOptions<IndexOptions> options)
     {
-        _serviceProvider = serviceProvider;
-        _logger = logger;
+        _indexerResolver = indexerResolver;
         _options = options.Value;
     }
 
@@ -36,9 +30,10 @@ public class GetAllIndexesApiController : ApiControllerBase
         List<IndexViewModel> indexes = [];
         foreach (ContentIndexRegistration indexRegistration in _options.GetContentIndexRegistrations())
         {
-            if (TryGetIndexer(_serviceProvider, indexRegistration.Indexer, _logger, out IIndexer? indexer) is false)
+            IIndexer? indexer = _indexerResolver.GetIndexer(indexRegistration.IndexAlias);
+            if (indexer is null)
             {
-                _logger.LogError($"Could not resolve type {{type}} as {nameof(IIndexer)}. Make sure the type is registered in the DI.", indexRegistration.Indexer.FullName);
+                // NOTE: logging is handled by the resolver
                 continue;
             }
 

--- a/src/Umbraco.Cms.Search.Core/Controllers/GetIndexApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/GetIndexApiController.cs
@@ -1,10 +1,6 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Umbraco.Cms.Search.Core.Configuration;
-using Umbraco.Cms.Search.Core.Models.Configuration;
 using Umbraco.Cms.Search.Core.Models.Indexing;
 using Umbraco.Cms.Search.Core.Models.ViewModels;
 using Umbraco.Cms.Search.Core.Services;
@@ -14,19 +10,10 @@ namespace Umbraco.Cms.Search.Core.Controllers;
 [ApiVersion("1.0")]
 public class GetIndexApiController : ApiControllerBase
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<GetAllIndexesApiController> _logger;
-    private readonly IndexOptions _options;
+    private readonly IIndexerResolver _indexerResolver;
 
-    public GetIndexApiController(
-        IOptions<IndexOptions> options,
-        IServiceProvider serviceProvider,
-        ILogger<GetAllIndexesApiController> logger)
-    {
-        _serviceProvider = serviceProvider;
-        _logger = logger;
-        _options = options.Value;
-    }
+    public GetIndexApiController(IIndexerResolver indexerResolver)
+        => _indexerResolver = indexerResolver;
 
     [HttpGet("indexes/{indexAlias}")]
     [ProducesResponseType<IndexViewModel>(StatusCodes.Status200OK)]
@@ -39,22 +26,17 @@ public class GetIndexApiController : ApiControllerBase
             return BadRequest("The indexAlias parameter must be provided and cannot be empty.");
         }
 
-        ContentIndexRegistration? indexRegistration = _options.GetContentIndexRegistration(indexAlias);
-        if (indexRegistration is null)
-        {
-            return NotFound("The specified index alias was not found.");
-        }
-
-        if (TryGetIndexer(_serviceProvider, indexRegistration.Indexer, _logger, out IIndexer? indexer) is false)
+        IIndexer? indexer = _indexerResolver.GetIndexer(indexAlias);
+        if (indexer is null)
         {
             return NotFound("Could not resolve the indexer for the specified index.");
         }
 
-        IndexMetadata indexMetadata = await indexer.GetMetadataAsync(indexRegistration.IndexAlias);
+        IndexMetadata indexMetadata = await indexer.GetMetadataAsync(indexAlias);
 
         return Ok(new IndexViewModel
         {
-            IndexAlias = indexRegistration.IndexAlias,
+            IndexAlias = indexAlias,
             DocumentCount = indexMetadata.DocumentCount,
             HealthStatus = indexMetadata.HealthStatus,
         });

--- a/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -31,6 +31,7 @@ public static class UmbracoBuilderExtensions
     {
         builder.Services.AddSingleton<IContentIndexingService, ContentIndexingService>();
         builder.Services.AddSingleton<ISearcherResolver, SearcherResolver>();
+        builder.Services.AddSingleton<IIndexerResolver, IndexerResolver>();
         builder.Services.AddTransient<IHtmlIndexValueParser, HtmlIndexValueParser>();
 
         builder.Services.AddTransient<IContentIndexingDataCollectionService, ContentIndexingDataCollectionService>();

--- a/src/Umbraco.Cms.Search.Core/Extensions/IndexerResolverExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/Extensions/IndexerResolverExtensions.cs
@@ -1,0 +1,10 @@
+﻿using Umbraco.Cms.Search.Core.Services;
+
+namespace Umbraco.Cms.Search.Core.Extensions;
+
+public static class IndexerResolverExtensions
+{
+    public static IIndexer GetRequiredIndexer(this IIndexerResolver indexerResolver, string indexAlias)
+        => indexerResolver.GetIndexer(indexAlias)
+           ?? throw new InvalidOperationException($"No indexer was registered for the index: {indexAlias}. Check the logs for more information.");
+}

--- a/src/Umbraco.Cms.Search.Core/Services/IIndexerResolver.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/IIndexerResolver.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Search.Core.Services;
+
+public interface IIndexerResolver
+{
+    public IIndexer? GetIndexer(string indexAlias);
+}

--- a/src/Umbraco.Cms.Search.Core/Services/IndexerResolver.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/IndexerResolver.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Search.Core.Configuration;
+
+namespace Umbraco.Cms.Search.Core.Services;
+
+internal sealed class IndexerResolver : ResolverBase<IIndexer>, IIndexerResolver
+{
+    public IndexerResolver(IOptions<IndexOptions> indexOptions, IServiceProvider serviceProvider, ILogger<IndexerResolver> logger)
+        : base(indexOptions, serviceProvider, logger)
+    {
+    }
+
+    public IIndexer? GetIndexer(string indexAlias)
+        => Resolve(indexAlias, indexRegistration => indexRegistration.Indexer);
+}

--- a/src/Umbraco.Cms.Search.Core/Services/ResolverBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ResolverBase.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Search.Core.Configuration;
+using Umbraco.Cms.Search.Core.Models.Configuration;
+
+namespace Umbraco.Cms.Search.Core.Services;
+
+internal abstract class ResolverBase<T>
+    where T : class
+{
+    private readonly IndexOptions _indexOptions;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger _logger;
+
+    protected ResolverBase(IOptions<IndexOptions> indexOptions, IServiceProvider serviceProvider, ILogger logger)
+    {
+        _indexOptions = indexOptions.Value;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected T? Resolve(string indexAlias, Func<IndexRegistration, Type> getTypeToResolve)
+    {
+        IndexRegistration? indexRegistration = _indexOptions.GetIndexRegistration(indexAlias);
+        if (indexRegistration is null)
+        {
+            _logger.LogWarning("No index registration was found for index alias: {indexAlias}", indexAlias);
+            return null;
+        }
+
+        Type typeToResolve = getTypeToResolve(indexRegistration);
+        if (_serviceProvider.GetService(typeToResolve) is not T resolved)
+        {
+            _logger.LogError($"Could not resolve type {{type}} as {typeof(T).Name}. Make sure the type is registered in the DI.", typeToResolve.FullName);
+            return null;
+        }
+
+        return resolved;
+    }
+}

--- a/src/Umbraco.Cms.Search.Core/Services/SearcherResolver.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/SearcherResolver.cs
@@ -1,38 +1,16 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Search.Core.Configuration;
-using Umbraco.Cms.Search.Core.Models.Configuration;
 
 namespace Umbraco.Cms.Search.Core.Services;
 
-internal sealed class SearcherResolver : ISearcherResolver
+internal sealed class SearcherResolver : ResolverBase<ISearcher>, ISearcherResolver
 {
-    private readonly IndexOptions _indexOptions;
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<SearcherResolver> _logger;
-
     public SearcherResolver(IOptions<IndexOptions> indexOptions, IServiceProvider serviceProvider, ILogger<SearcherResolver> logger)
+        : base(indexOptions, serviceProvider, logger)
     {
-        _indexOptions = indexOptions.Value;
-        _serviceProvider = serviceProvider;
-        _logger = logger;
     }
 
     public ISearcher? GetSearcher(string indexAlias)
-    {
-        IndexRegistration? indexRegistration = _indexOptions.GetIndexRegistration(indexAlias);
-        if (indexRegistration is null)
-        {
-            _logger.LogWarning("No index registration was found for index alias: {indexAlias}", indexAlias);
-            return null;
-        }
-
-        if (_serviceProvider.GetService(indexRegistration.Searcher) is not ISearcher searcher)
-        {
-            _logger.LogError($"Could not resolve type {{type}} as {nameof(ISearcher)}. Make sure the type is registered in the DI.", indexRegistration.Searcher.FullName);
-            return null;
-        }
-
-        return searcher;
-    }
+        => Resolve(indexAlias, indexRegistration => indexRegistration.Searcher);
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/CustomIndexRegistrationTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/CustomIndexRegistrationTests.cs
@@ -52,6 +52,13 @@ public class CustomIndexRegistrationTests : TestBase
     }
 
     [Test]
+    public void Can_Resolve_Required_Indexer()
+    {
+        IIndexerResolver indexerResolver = GetRequiredService<IIndexerResolver>();
+        Assert.That(indexerResolver.GetRequiredIndexer(IndexAlias), Is.TypeOf<TestIndexerAndSearcher>());
+    }
+
+    [Test]
     public async Task Can_Populate_Custom_Index()
     {
         IIndexer indexer = GetRequiredService<IIndexer>();

--- a/src/Umbraco.Test.Search.Integration/Tests/IndexerResolverTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/IndexerResolverTests.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Search.Core.Configuration;
+using Umbraco.Cms.Search.Core.DependencyInjection;
+using Umbraco.Cms.Search.Core.Services;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+[TestFixture]
+internal class IndexerResolverTests : ResolverTestsBase<IndexerResolver>
+{
+    private IIndexerResolver IndexerResolver => GetRequiredService<IIndexerResolver>();
+
+    private Mock<ILogger<IndexerResolver>>? _loggerMock;
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        base.CustomTestSetup(builder);
+
+        builder.AddSearchCore();
+
+        builder.Services.AddTransient<FirstIndexer>();
+        builder.Services.AddTransient<SecondIndexer>();
+
+        builder.Services.Configure<IndexOptions>(options =>
+        {
+            options.RegisterContentIndex<FirstIndexer, Searcher, TestContentChangeStrategy>("FirstIndex", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<SecondIndexer, Searcher, TestContentChangeStrategy>("SecondIndex", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<ThirdIndexer, Searcher, TestContentChangeStrategy>("IndexWithUnregisteredIndexer", UmbracoObjectTypes.Document);
+        });
+
+        _loggerMock = new Mock<ILogger<IndexerResolver>>();
+        builder.Services.AddSingleton(_loggerMock.Object);
+    }
+
+    [Test]
+    public void FirstIndex_ResolvesFirstIndexer()
+    {
+        IIndexer? indexer = IndexerResolver.GetIndexer("FirstIndex");
+        Assert.That(indexer, Is.Not.Null);
+        Assert.That(indexer, Is.TypeOf<FirstIndexer>());
+    }
+
+    [Test]
+    public void SecondIndex_ResolvesSecondIndexer()
+    {
+        IIndexer? indexer = IndexerResolver.GetIndexer("SecondIndex");
+        Assert.That(indexer, Is.Not.Null);
+        Assert.That(indexer, Is.TypeOf<SecondIndexer>());
+    }
+
+    [Test]
+    public void UnknownIndex_ResolvesNoIndexer()
+    {
+        IIndexer? indexer = IndexerResolver.GetIndexer("UnknownIndex");
+        Assert.That(indexer, Is.Null);
+        VerifyLogging(LogLevel.Warning, "No index registration was found");
+    }
+
+    [Test]
+    public void UnregisteredIndexer_ResolvesNoIndexer()
+    {
+        IIndexer? indexer = IndexerResolver.GetIndexer("IndexWithUnregisteredIndexer");
+        Assert.That(indexer, Is.Null);
+        VerifyLogging(LogLevel.Error, "Could not resolve type");
+    }
+
+    private void VerifyLogging(LogLevel logLevel, string startOfMessage)
+        => VerifyLogging(_loggerMock!, logLevel, startOfMessage);
+
+    private class Searcher : SearcherBase
+    {
+    }
+
+    private class FirstIndexer : IndexerBase
+    {
+    }
+
+    private class SecondIndexer : IndexerBase
+    {
+    }
+
+    private class ThirdIndexer : IndexerBase
+    {
+    }
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/ResolverTestsBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ResolverTestsBase.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Models.Searching;
+using Umbraco.Cms.Search.Core.Models.Searching.Faceting;
+using Umbraco.Cms.Search.Core.Models.Searching.Filtering;
+using Umbraco.Cms.Search.Core.Models.Searching.Sorting;
+using Umbraco.Cms.Search.Core.Services;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+[UmbracoTest(Database = UmbracoTestOptions.Database.None)]
+internal abstract class ResolverTestsBase<TResolver> : UmbracoIntegrationTest
+{
+    protected static void VerifyLogging(Mock<ILogger<TResolver>> loggerMock, LogLevel logLevel, string startOfMessage)
+        => loggerMock.Verify(logger =>
+            logger.Log(
+                logLevel,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((value, _) => value.ToString()!.StartsWith(startOfMessage)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+
+    protected class TestContentChangeStrategy : IContentChangeStrategy
+    {
+        public Task HandleAsync(IEnumerable<ContentIndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task RebuildAsync(ContentIndexInfo indexInfo, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+
+    protected abstract class IndexerBase : IIndexer
+    {
+        public Task AddOrUpdateAsync(string indexAlias, Guid id, UmbracoObjectTypes objectType, IEnumerable<Variation> variations, IEnumerable<IndexField> fields, ContentProtection? protection)
+            => throw new NotImplementedException();
+
+        public Task DeleteAsync(string indexAlias, IEnumerable<Guid> ids)
+            => throw new NotImplementedException();
+
+        public Task ResetAsync(string indexAlias)
+            => throw new NotImplementedException();
+
+        public Task<IndexMetadata> GetMetadataAsync(string indexAlias)
+            => Task.FromResult(new IndexMetadata(0, HealthStatus.Healthy));
+    }
+
+    protected abstract class SearcherBase : ISearcher
+    {
+        public Task<SearchResult> SearchAsync(
+            string indexAlias,
+            string? query = null,
+            IEnumerable<Filter>? filters = null,
+            IEnumerable<Facet>? facets = null,
+            IEnumerable<Sorter>? sorters = null,
+            string? culture = null,
+            string? segment = null,
+            AccessContext? accessContext = null,
+            int skip = 0,
+            int take = 10,
+            int maxSuggestions = 0)
+            => throw new NotImplementedException();
+    }
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/SearcherResolverTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/SearcherResolverTests.cs
@@ -4,23 +4,15 @@ using Moq;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Core.Configuration;
 using Umbraco.Cms.Search.Core.DependencyInjection;
-using Umbraco.Cms.Search.Core.Models.Indexing;
-using Umbraco.Cms.Search.Core.Models.Searching;
-using Umbraco.Cms.Search.Core.Models.Searching.Faceting;
-using Umbraco.Cms.Search.Core.Models.Searching.Filtering;
-using Umbraco.Cms.Search.Core.Models.Searching.Sorting;
 using Umbraco.Cms.Search.Core.Services;
-using Umbraco.Cms.Search.Core.Services.ContentIndexing;
-using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Cms.Tests.Integration.Testing;
 
 namespace Umbraco.Test.Search.Integration.Tests;
 
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.None)]
-public class SearcherResolverTests : UmbracoIntegrationTest
+internal class SearcherResolverTests : ResolverTestsBase<SearcherResolver>
 {
     private ISearcherResolver SearcherResolver => GetRequiredService<ISearcherResolver>();
+
     private Mock<ILogger<SearcherResolver>>? _loggerMock;
 
     protected override void CustomTestSetup(IUmbracoBuilder builder)
@@ -34,9 +26,9 @@ public class SearcherResolverTests : UmbracoIntegrationTest
 
         builder.Services.Configure<IndexOptions>(options =>
         {
-            options.RegisterContentIndex<TestIndexer, FirstSearcher, TestContentChangeStrategy>("FirstIndex", UmbracoObjectTypes.Document);
-            options.RegisterContentIndex<TestIndexer, SecondSearcher, TestContentChangeStrategy>("SecondIndex", UmbracoObjectTypes.Document);
-            options.RegisterContentIndex<TestIndexer, UnregisteredSearcher, TestContentChangeStrategy>("IndexWithUnregisteredSearcher", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<Indexer, FirstSearcher, TestContentChangeStrategy>("FirstIndex", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<Indexer, SecondSearcher, TestContentChangeStrategy>("SecondIndex", UmbracoObjectTypes.Document);
+            options.RegisterContentIndex<Indexer, UnregisteredSearcher, TestContentChangeStrategy>("IndexWithUnregisteredSearcher", UmbracoObjectTypes.Document);
         });
 
         _loggerMock = new Mock<ILogger<SearcherResolver>>();
@@ -76,13 +68,7 @@ public class SearcherResolverTests : UmbracoIntegrationTest
     }
 
     private void VerifyLogging(LogLevel logLevel, string startOfMessage)
-        => _loggerMock!.Verify(logger =>
-            logger.Log(
-                logLevel,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((value, _) => value.ToString()!.StartsWith(startOfMessage)),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+        => VerifyLogging(_loggerMock!, logLevel, startOfMessage);
 
     private class FirstSearcher : SearcherBase
     {
@@ -96,44 +82,7 @@ public class SearcherResolverTests : UmbracoIntegrationTest
     {
     }
 
-    private class TestContentChangeStrategy : IContentChangeStrategy
+    private class Indexer : IndexerBase
     {
-        public Task HandleAsync(IEnumerable<ContentIndexInfo> indexInfos, IEnumerable<ContentChange> changes, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-
-        public Task RebuildAsync(ContentIndexInfo indexInfo, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-    }
-
-    private class TestIndexer : IIndexer
-    {
-        public Task AddOrUpdateAsync(string indexAlias, Guid id, UmbracoObjectTypes objectType, IEnumerable<Variation> variations, IEnumerable<IndexField> fields, ContentProtection? protection)
-            => throw new NotImplementedException();
-
-        public Task DeleteAsync(string indexAlias, IEnumerable<Guid> ids)
-            => throw new NotImplementedException();
-
-        public Task ResetAsync(string indexAlias)
-            => throw new NotImplementedException();
-
-        public Task<IndexMetadata> GetMetadataAsync(string indexAlias)
-            => Task.FromResult(new IndexMetadata(0, HealthStatus.Healthy));
-    }
-
-    private abstract class SearcherBase : ISearcher
-    {
-        public Task<SearchResult> SearchAsync(
-            string indexAlias,
-            string? query = null,
-            IEnumerable<Filter>? filters = null,
-            IEnumerable<Facet>? facets = null,
-            IEnumerable<Sorter>? sorters = null,
-            string? culture = null,
-            string? segment = null,
-            AccessContext? accessContext = null,
-            int skip = 0,
-            int take = 10,
-            int maxSuggestions = 0)
-            => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
We can resolve searchers dynamically with the `ISearcherResolver` ... this PR adds a corresponding option to resolve indexers with an `IIndexerResolver`.