### PR TITLE
Omit system fields in the Examine field browser (closes #91)

### DIFF
--- a/src/Umbraco.Cms.Search.Provider.Examine/Controllers/ExamineApiController.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Controllers/ExamineApiController.cs
@@ -48,7 +48,9 @@ public class ExamineApiController : ExamineApiControllerBase
 
         var indexDocumentViewModels = results.Select(result => new IndexDocumentViewModel()
             {
-                Fields = result.AllValues.Select(kvp => ParseField(kvp.Key, kvp.Value))
+                Fields = result.AllValues
+                    .Where(kvp => ShouldDisplayField(kvp.Key))
+                    .Select(kvp => ParseField(kvp.Key, kvp.Value))
                     .ToList()
                     .AsReadOnly(),
             })
@@ -62,6 +64,10 @@ public class ExamineApiController : ExamineApiControllerBase
 
 
         return Ok(documentViewModel);
+
+        // determines if a field should be displayed to the users:
+        // - system fields (including our own) should be omitted. they all start with "__".
+        bool ShouldDisplayField(string fieldName) => fieldName.StartsWith("__") is false;
     }
 
     private static FieldViewModel ParseField(string fieldName, IEnumerable<string> values)


### PR DESCRIPTION
As pointed out in #91, we currently show system fields (including our own) in the Examine field browser:

<img width="880" height="956" alt="image" src="https://github.com/user-attachments/assets/fd4cf7c0-6417-45f3-88ff-9ada57686f24" />

These yield little value to the user. If anything, they're downright confusing... so I have remove them in this PR:

<img width="880" height="956" alt="image" src="https://github.com/user-attachments/assets/696bd770-5bf7-4a34-9912-286327570e10" />
