### PR TITLE
Chore: Clean up constants and don't use hardcoded Examine system field names

### DIFF
--- a/src/Umbraco.Cms.Search.Provider.Examine/Configuration/ConfigureIndexOptions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Configuration/ConfigureIndexOptions.cs
@@ -133,7 +133,6 @@ internal sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirec
         [
             new() { PropertyName = Constants.SystemFields.Protection, FieldValues = FieldValues.Keywords },
             new() { PropertyName = Constants.SystemFields.Culture, FieldValues = FieldValues.Keywords },
-            new() { PropertyName = Constants.SystemFields.Segment, FieldValues = FieldValues.Keywords },
             new() { PropertyName = Constants.SystemFields.AggregatedTexts, FieldValues = FieldValues.Texts },
             new() { PropertyName = Constants.SystemFields.AggregatedTextsR1, FieldValues = FieldValues.Texts },
             new() { PropertyName = Constants.SystemFields.AggregatedTextsR2, FieldValues = FieldValues.Texts },

--- a/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
@@ -30,13 +30,10 @@ internal static class Constants
 
         public const string Protection = $"{Prefix}Protection";
         public const string Culture = $"{Prefix}Culture";
-        public const string Segment = $"{Prefix}Segment";
 
         public const string AggregatedTexts = $"{Prefix}aggregated_texts";
         public const string AggregatedTextsR1 = $"{Prefix}aggregated_textsr1";
         public const string AggregatedTextsR2 = $"{Prefix}aggregated_textsr2";
         public const string AggregatedTextsR3 = $"{Prefix}aggregated_textsr3";
-
-        public const string IndexType = "__IndexType";
     }
 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -159,7 +159,7 @@ public class Searcher : IExamineSearcher
         AddSorters(searchQuery, sortersAsArray, culture, segment);
 
         // We only need the IndexType and NodeId
-        var selectedFields = new HashSet<string> {Constants.SystemFields.IndexType, "__NodeId" };
+        var selectedFields = new HashSet<string> { ExamineFieldNames.CategoryFieldName, ExamineFieldNames.ItemIdFieldName };
         searchQuery.SelectFields(selectedFields);
 
         ISearchResults results;
@@ -518,7 +518,7 @@ public class Searcher : IExamineSearcher
 
     private static Document? MapToDocument(ISearchResult item)
     {
-        var objectTypeString = item.Values.GetValueOrDefault(Constants.SystemFields.IndexType);
+        var objectTypeString = item.Values.GetValueOrDefault(ExamineFieldNames.CategoryFieldName);
 
         Enum.TryParse(objectTypeString, out UmbracoObjectTypes umbracoObjectType);
 


### PR DESCRIPTION
I found a left-over constant (`Segment`) which is no longer used, and then I realized that we had hardcoded some of the internal Examine constants too... so I removed those as well 😄 