### PR TITLE
Add distributed index refresher

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Cache/Content/DraftContentNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Content/DraftContentNotificationHandler.cs
@@ -23,22 +23,25 @@ internal sealed class DraftContentNotificationHandler : ContentNotificationHandl
     {
     }
 
-    public void Handle(ContentSavedNotification notification)
+    public void Refresh(IEnumerable<IContent> entities)
     {
-        IContent[] savedEntities = notification.SavedEntities.ToArray();
-        if (savedEntities.Length is 0)
+        IContent[] entitiesAsArray = entities as IContent[] ?? entities.ToArray();
+        if (entitiesAsArray.Length is 0)
         {
             return;
         }
 
-        FlushDocumentIndexCache(savedEntities);
+        FlushDocumentIndexCache(entitiesAsArray);
 
-        DraftContentCacheRefresher.JsonPayload[] payloads = savedEntities
+        DraftContentCacheRefresher.JsonPayload[] payloads = entitiesAsArray
             .Select(entity => new DraftContentCacheRefresher.JsonPayload(entity.Key, TreeChangeTypes.RefreshNode))
             .ToArray();
 
         HandlePayloads(payloads);
     }
+
+    public void Handle(ContentSavedNotification notification)
+        => Refresh(notification.SavedEntities);
 
     public void Handle(ContentMovedNotification notification)
         => HandleMove(notification.MoveInfoCollection);

--- a/src/Umbraco.Cms.Search.Core/Cache/Content/PublishedContentNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Content/PublishedContentNotificationHandler.cs
@@ -120,8 +120,5 @@ internal sealed class PublishedContentNotificationHandler : ContentNotificationH
     }
 
     private void FlushDocumentIndexCache(IEnumerable<IContent> entities)
-        => FlushDocumentIndexCache(entities.Select(x => x.Key).ToArray());
-
-    private void FlushDocumentIndexCache(Guid[] ids)
-        => FlushDocumentIndexCache(ids, true);
+        => FlushDocumentIndexCache(entities.Select(x => x.Key).ToArray(), true);
 }

--- a/src/Umbraco.Cms.Search.Core/Cache/Content/PublishedContentNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Content/PublishedContentNotificationHandler.cs
@@ -24,6 +24,28 @@ internal sealed class PublishedContentNotificationHandler : ContentNotificationH
     {
     }
 
+
+    public void Refresh(IEnumerable<IContent> entities)
+    {
+        IContent[] entitiesAsArray = entities as IContent[] ?? entities.ToArray();
+        if (entitiesAsArray.Length is 0)
+        {
+            return;
+        }
+
+        FlushDocumentIndexCache(entitiesAsArray);
+
+        PublishedContentCacheRefresher.JsonPayload[] payloads = entitiesAsArray
+            .Select(entity =>
+                new PublishedContentCacheRefresher.JsonPayload(
+                    entity.Key,
+                    TreeChangeTypes.RefreshNode,
+                    entity.PublishedCultures.ToArray()))
+            .ToArray();
+
+        HandlePayloads(payloads);
+    }
+
     public void Handle(ContentPublishedNotification notification)
     {
         // we sometimes get unpublished entities here... filter those out, we don't need them
@@ -98,5 +120,8 @@ internal sealed class PublishedContentNotificationHandler : ContentNotificationH
     }
 
     private void FlushDocumentIndexCache(IEnumerable<IContent> entities)
-        => FlushDocumentIndexCache(entities.Select(x => x.Key).ToArray(), true);
+        => FlushDocumentIndexCache(entities.Select(x => x.Key).ToArray());
+
+    private void FlushDocumentIndexCache(Guid[] ids)
+        => FlushDocumentIndexCache(ids, true);
 }

--- a/src/Umbraco.Cms.Search.Core/Cache/Media/DraftMediaNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Media/DraftMediaNotificationHandler.cs
@@ -23,22 +23,25 @@ internal sealed class DraftMediaNotificationHandler : ContentNotificationHandler
     {
     }
 
-    public void Handle(MediaSavedNotification notification)
+    public void Refresh(IEnumerable<IMedia> entities)
     {
-        IMedia[] savedEntities = notification.SavedEntities.ToArray();
-        if (savedEntities.Length is 0)
+        IMedia[] entitiesAsArray = entities as IMedia[] ?? entities.ToArray();
+        if (entitiesAsArray.Length is 0)
         {
             return;
         }
 
-        FlushDocumentIndexCache(savedEntities);
+        FlushDocumentIndexCache(entitiesAsArray);
 
-        DraftMediaCacheRefresher.JsonPayload[] payloads = savedEntities
+        DraftMediaCacheRefresher.JsonPayload[] payloads = entitiesAsArray
             .Select(entity => new DraftMediaCacheRefresher.JsonPayload(entity.Key, TreeChangeTypes.RefreshNode))
             .ToArray();
 
         HandlePayloads(payloads);
     }
+
+    public void Handle(MediaSavedNotification notification)
+        => Refresh(notification.SavedEntities);
 
     public void Handle(MediaMovedNotification notification)
         => HandleMove(notification.MoveInfoCollection);

--- a/src/Umbraco.Cms.Search.Core/Cache/Member/DraftMemberNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Member/DraftMemberNotificationHandler.cs
@@ -20,22 +20,25 @@ internal sealed class DraftMemberNotificationHandler : ContentNotificationHandle
     {
     }
 
-    public void Handle(MemberSavedNotification notification)
+    public void Refresh(IEnumerable<IMember> entities)
     {
-        IMember[] savedEntities = notification.SavedEntities.ToArray();
-        if (savedEntities.Length is 0)
+        IMember[] entitiesAsArray = entities as IMember[] ?? entities.ToArray();
+        if (entitiesAsArray.Length is 0)
         {
             return;
         }
 
-        FlushDocumentIndexCache(savedEntities);
+        FlushDocumentIndexCache(entitiesAsArray);
 
-        DraftMemberCacheRefresher.JsonPayload[] payloads = savedEntities
+        DraftMemberCacheRefresher.JsonPayload[] payloads = entitiesAsArray
             .Select(entity => new DraftMemberCacheRefresher.JsonPayload(entity.Key, TreeChangeTypes.RefreshNode))
             .ToArray();
 
         HandlePayloads(payloads);
     }
+
+    public void Handle(MemberSavedNotification notification)
+        => Refresh(notification.SavedEntities);
 
     public void Handle(MemberDeletedNotification notification)
     {

--- a/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -57,6 +57,13 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IIndexDocumentRepository, IndexDocumentRepository>();
         builder.Services.AddSingleton<IIndexDocumentService, IndexDocumentService>();
 
+        // we need these notification handlers explicitly registered for the distributed content index refresher
+        builder.Services.AddTransient<DraftContentNotificationHandler>();
+        builder.Services.AddTransient<PublishedContentNotificationHandler>();
+        builder.Services.AddTransient<DraftMediaNotificationHandler>();
+        builder.Services.AddTransient<DraftMemberNotificationHandler>();
+        builder.Services.AddTransient<IDistributedContentIndexRefresher, DistributedContentIndexRefresher>();
+
         builder
             .AddNotificationHandler<LanguageCacheRefresherNotification, RebuildIndexesNotificationHandler>()
             .AddNotificationHandler<ContentTypeCacheRefresherNotification, RebuildIndexesNotificationHandler>()

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DistributedContentIndexRefresher.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DistributedContentIndexRefresher.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Search.Core.Models.Indexing;
 
 namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
 
-internal class DistributedContentIndexRefresher : IDistributedContentIndexRefresher
+internal sealed class DistributedContentIndexRefresher : IDistributedContentIndexRefresher
 {
     private readonly DraftContentNotificationHandler _draftContentNotificationHandler;
     private readonly PublishedContentNotificationHandler _publishedContentNotificationHandler;

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DistributedContentIndexRefresher.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DistributedContentIndexRefresher.cs
@@ -1,0 +1,48 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Search.Core.Cache.Content;
+using Umbraco.Cms.Search.Core.Cache.Media;
+using Umbraco.Cms.Search.Core.Cache.Member;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+
+namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
+
+internal class DistributedContentIndexRefresher : IDistributedContentIndexRefresher
+{
+    private readonly DraftContentNotificationHandler _draftContentNotificationHandler;
+    private readonly PublishedContentNotificationHandler _publishedContentNotificationHandler;
+    private readonly DraftMediaNotificationHandler _draftMediaNotificationHandler;
+    private readonly DraftMemberNotificationHandler _draftMemberNotificationHandler;
+
+    public DistributedContentIndexRefresher(
+        DraftContentNotificationHandler draftContentNotificationHandler,
+        PublishedContentNotificationHandler publishedContentNotificationHandler,
+        DraftMediaNotificationHandler draftMediaNotificationHandler,
+        DraftMemberNotificationHandler draftMemberNotificationHandler)
+    {
+        _draftContentNotificationHandler = draftContentNotificationHandler;
+        _publishedContentNotificationHandler = publishedContentNotificationHandler;
+        _draftMediaNotificationHandler = draftMediaNotificationHandler;
+        _draftMemberNotificationHandler = draftMemberNotificationHandler;
+    }
+
+    public void RefreshContent(IEnumerable<IContent> entities, ContentState contentState)
+    {
+        switch (contentState)
+        {
+            case ContentState.Draft:
+                _draftContentNotificationHandler.Refresh(entities);
+                break;
+            case ContentState.Published:
+                _publishedContentNotificationHandler.Refresh(entities);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(contentState), contentState, null);
+        }
+    }
+
+    public void RefreshMedia(IEnumerable<IMedia> entities)
+        => _draftMediaNotificationHandler.Refresh(entities);
+
+    public void RefreshMember(IEnumerable<IMember> entities)
+        => _draftMemberNotificationHandler.Refresh(entities);
+}

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IDistributedContentIndexRefresher.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IDistributedContentIndexRefresher.cs
@@ -1,0 +1,13 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+
+namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
+
+public interface IDistributedContentIndexRefresher
+{
+    void RefreshContent(IEnumerable<IContent> entities, ContentState contentState);
+
+    void RefreshMedia(IEnumerable<IMedia> entities);
+
+    void RefreshMember(IEnumerable<IMember> entities);
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRefresherContentTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRefresherContentTests.cs
@@ -1,0 +1,155 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Test.Search.Integration.Services;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class DistributedContentIndexRefresherContentTests : TestBase
+{
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IDistributedContentIndexRefresher DistributedContentIndexRefresher => GetRequiredService<IDistributedContentIndexRefresher>();
+
+    private Guid _variantContentKey;
+
+    private Guid _invariantContentKey;
+
+    [SetUp]
+    public async Task SetupTest()
+    {
+        await GetRequiredService<ILanguageService>().CreateAsync(
+            new LanguageBuilder().WithCultureInfo("da-DK").Build(),
+            Constants.Security.SuperUserKey);
+
+        IContentType variantContentType = new ContentTypeBuilder()
+            .WithAlias("variant")
+            .WithContentVariation(ContentVariation.CultureAndSegment)
+            .WithAllowAsRoot(true)
+            .Build();
+        await ContentTypeService.CreateAsync(variantContentType, Constants.Security.SuperUserKey);
+
+        IContentType invariantContentType = new ContentTypeBuilder()
+            .WithAlias("invariant")
+            .WithAllowAsRoot(true)
+            .Build();
+        await ContentTypeService.CreateAsync(invariantContentType, Constants.Security.SuperUserKey);
+
+        _variantContentKey = Guid.NewGuid();
+        IContent variantContent = new ContentBuilder()
+            .WithKey(_variantContentKey)
+            .WithContentType(variantContentType)
+            .WithCultureName("en-US", "Variant EN")
+            .WithCultureName("da-DK", "Variant DA")
+            .Build();
+        ContentService.Save(variantContent);
+        ContentService.Publish(variantContent, ["en-US", "da-DK"]);
+
+        _invariantContentKey = Guid.NewGuid();
+        IContent invariantContent = new ContentBuilder()
+            .WithKey(_invariantContentKey)
+            .WithContentType(invariantContentType)
+            .WithName("Invariant")
+            .Build();
+        ContentService.Save(invariantContent);
+        ContentService.Publish(invariantContent, ["*"]);
+
+        IndexerAndSearcher.Reset();
+    }
+
+    [Test]
+    public void RefreshContent_SingleDraft()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.DraftContent), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshContent([InvariantContent()], ContentState.Draft);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
+
+        Assert.That(dump, Has.Count.EqualTo(1));
+        Assert.That(dump[0].Id, Is.EqualTo(_invariantContentKey));
+    }
+
+    [Test]
+    public void RefreshContent_MultipleDraft()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.DraftContent), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshContent([InvariantContent(), VariantContent()], ContentState.Draft);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.DraftContent);
+
+        Assert.That(dump, Has.Count.EqualTo(2));
+        Assert.That(dump.Select(d => d.Id), Is.EquivalentTo(new[] { _invariantContentKey, _variantContentKey }));
+    }
+
+    [Test]
+    public void RefreshContent_SinglePublished()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.PublishedContent), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshContent([InvariantContent()], ContentState.Published);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
+
+        Assert.That(dump, Has.Count.EqualTo(1));
+        Assert.That(dump[0].Id, Is.EqualTo(_invariantContentKey));
+    }
+
+    [Test]
+    public void RefreshContent_MultiplePublished()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.PublishedContent), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshContent([InvariantContent(), VariantContent()], ContentState.Published);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
+
+        Assert.That(dump, Has.Count.EqualTo(2));
+        Assert.That(dump.Select(d => d.Id), Is.EquivalentTo(new[] { _invariantContentKey, _variantContentKey }));
+    }
+
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(true, true)]
+    public void RefreshContent_SinglePublished_SpecificLanguageVariants(bool publishEnglish, bool publishDanish)
+    {
+        ContentService.Unpublish(VariantContent());
+
+        var culturesToPublish = new List<string>();
+        if (publishEnglish)
+        {
+            culturesToPublish.Add("en-US");
+        }
+        if (publishDanish)
+        {
+            culturesToPublish.Add("da-DK");
+        }
+        ContentService.Publish(VariantContent(), culturesToPublish.ToArray());
+
+        IndexerAndSearcher.Reset();
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.PublishedContent), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshContent([VariantContent()], ContentState.Published);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.PublishedContent);
+
+        Assert.That(dump, Has.Count.EqualTo(1));
+        Assert.That(dump[0].Id, Is.EqualTo(_variantContentKey));
+        Assert.That(dump[0].Variations.Any(v => v.Culture == "en-US"), Is.EqualTo(publishEnglish));
+        Assert.That(dump[0].Variations.Any(v => v.Culture == "da-DK"), Is.EqualTo(publishDanish));
+    }
+
+    private IContent VariantContent() => ContentService.GetById(_variantContentKey) ?? throw new InvalidOperationException("Variant content was not found");
+
+    private IContent InvariantContent() => ContentService.GetById(_invariantContentKey) ?? throw new InvalidOperationException("Invariant content was not found");
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRefresherMediaTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRefresherMediaTests.cs
@@ -1,0 +1,82 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Test.Search.Integration.Services;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class DistributedContentIndexRefresherMediaTests : TestBase
+{
+    private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
+
+    private IMediaService MediaService => GetRequiredService<IMediaService>();
+
+    private IDistributedContentIndexRefresher DistributedContentIndexRefresher => GetRequiredService<IDistributedContentIndexRefresher>();
+
+    private Guid _mediaOneKey;
+    private Guid _mediaTwoKey;
+
+    [SetUp]
+    public async Task SetupTest()
+    {
+        IMediaType mediaType = new MediaTypeBuilder()
+            .WithAlias("invariant")
+            .WithAllowAsRoot(true)
+            .Build();
+        await MediaTypeService.CreateAsync(mediaType, Constants.Security.SuperUserKey);
+
+        _mediaOneKey = Guid.NewGuid();
+        IMedia mediaOne = new MediaBuilder()
+            .WithKey(_mediaOneKey)
+            .WithMediaType(mediaType)
+            .WithName("Media one")
+            .Build();
+        MediaService.Save(mediaOne);
+
+        _mediaTwoKey = Guid.NewGuid();
+        IMedia mediaTwo = new MediaBuilder()
+            .WithKey(_mediaTwoKey)
+            .WithMediaType(mediaType)
+            .WithName("Media two")
+            .Build();
+        MediaService.Save(mediaTwo);
+
+        IndexerAndSearcher.Reset();
+    }
+
+    [Test]
+    public void RefreshMedia_Single()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Media), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshMedia([MediaOne()]);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.Media);
+
+        Assert.That(dump, Has.Count.EqualTo(1));
+        Assert.That(dump[0].Id, Is.EqualTo(_mediaOneKey));
+    }
+
+    [Test]
+    public void RefreshMedia_Multiple()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Media), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshMedia([MediaOne(), MediaTwo()]);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.Media);
+
+        Assert.That(dump, Has.Count.EqualTo(2));
+        Assert.That(dump.Select(d => d.Id), Is.EquivalentTo(new[] { _mediaOneKey, _mediaTwoKey }));
+    }
+
+    private IMedia MediaOne() => MediaService.GetById(_mediaOneKey) ?? throw new InvalidOperationException("Media one was not found");
+
+    private IMedia MediaTwo() => MediaService.GetById(_mediaTwoKey) ?? throw new InvalidOperationException("Media two was not found");
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRefresherMemberTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRefresherMemberTests.cs
@@ -1,0 +1,82 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Test.Search.Integration.Services;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class DistributedContentIndexRefresherMemberTests : TestBase
+{
+    private IMemberTypeService MemberTypeService => GetRequiredService<IMemberTypeService>();
+
+    private IMemberService MemberService => GetRequiredService<IMemberService>();
+
+    private IDistributedContentIndexRefresher DistributedContentIndexRefresher => GetRequiredService<IDistributedContentIndexRefresher>();
+
+    private Guid _memberOneKey;
+    private Guid _memberTwoKey;
+
+    [SetUp]
+    public async Task SetupTest()
+    {
+        IMemberType memberType = new MemberTypeBuilder()
+            .WithAlias("invariant")
+            .WithAllowAsRoot(true)
+            .Build();
+        await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
+
+        _memberOneKey = Guid.NewGuid();
+        IMember memberOne = new MemberBuilder()
+            .WithKey(_memberOneKey)
+            .WithMemberType(memberType)
+            .WithName("Member one")
+            .Build();
+        MemberService.Save(memberOne);
+
+        _memberTwoKey = Guid.NewGuid();
+        IMember memberTwo = new MemberBuilder()
+            .WithKey(_memberTwoKey)
+            .WithMemberType(memberType)
+            .WithName("Member two")
+            .Build();
+        MemberService.Save(memberTwo);
+
+        IndexerAndSearcher.Reset();
+    }
+
+    [Test]
+    public void RefreshMember_Single()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Member), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshMember([MemberOne()]);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.Member);
+
+        Assert.That(dump, Has.Count.EqualTo(1));
+        Assert.That(dump[0].Id, Is.EqualTo(_memberOneKey));
+    }
+
+    [Test]
+    public void RefreshMember_Multiple()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Member), Is.Empty);
+
+        DistributedContentIndexRefresher.RefreshMember([MemberOne(), MemberTwo()]);
+
+        IReadOnlyList<TestIndexDocument> dump = IndexerAndSearcher.Dump(IndexAliases.Member);
+
+        Assert.That(dump, Has.Count.EqualTo(2));
+        Assert.That(dump.Select(d => d.Id), Is.EquivalentTo(new[] { _memberOneKey, _memberTwoKey }));
+    }
+
+    private IMember MemberOne() => MemberService.GetById(_memberOneKey) ?? throw new InvalidOperationException("Member one was not found");
+
+    private IMember MemberTwo() => MemberService.GetById(_memberTwoKey) ?? throw new InvalidOperationException("Member two was not found");
+}


### PR DESCRIPTION
This PR adds functionality for explicitly triggering an index refresh for one or more content items across all instances in a load balanced setup.

To avoid code duplication I have reused the existing notification handlers. It's not the prettiest of solutions if I'm honest, but it ensures correct behaviour without exposing too much of the underlying notification implementation.

Also, all of the implementation remains `internal sealed`, so if need be, we can retrofit the implementation at a later time.