### PR TITLE
Add distributed content index rebuilding

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Cache/Index/RebuildIndexCacheRefresher.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Index/RebuildIndexCacheRefresher.cs
@@ -1,0 +1,23 @@
+﻿using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Cms.Search.Core.Cache.Index;
+
+internal sealed class RebuildIndexCacheRefresher : PayloadCacheRefresherBase<RebuildIndexCacheRefresherNotification, ContentCacheRefresherNotificationPayload<RebuildIndexCacheRefresher.JsonPayload>>
+{
+    public static readonly Guid UniqueId = Guid.Parse("5268743B-7D6B-47A1-A9C8-1C03F2FFE242");
+
+    public RebuildIndexCacheRefresher(AppCaches appCaches, IJsonSerializer serializer, IEventAggregator eventAggregator, ICacheRefresherNotificationFactory factory)
+        : base(appCaches, serializer, eventAggregator, factory)
+    {
+    }
+
+    public override Guid RefresherUniqueId => UniqueId;
+
+    public override string Name => "Reindex Cache Refresher";
+
+    public record JsonPayload(string IndexAlias)
+    {
+    }
+}

--- a/src/Umbraco.Cms.Search.Core/Cache/Index/RebuildIndexCacheRefresherNotification.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Index/RebuildIndexCacheRefresherNotification.cs
@@ -1,0 +1,12 @@
+﻿using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Search.Core.Cache.Index;
+
+internal sealed class RebuildIndexCacheRefresherNotification : CacheRefresherNotification
+{
+    public RebuildIndexCacheRefresherNotification(object messageObject, MessageType messageType)
+        : base(messageObject, messageType)
+    {
+    }
+}

--- a/src/Umbraco.Cms.Search.Core/Cache/Index/RebuildIndexNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Index/RebuildIndexNotificationHandler.cs
@@ -1,0 +1,26 @@
+﻿using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+
+namespace Umbraco.Cms.Search.Core.Cache.Index;
+
+internal sealed class RebuildIndexNotificationHandler : ContentNotificationHandlerBase<RebuildIndexCacheRefresher.JsonPayload>
+{
+    protected override Guid CacheRefresherUniqueId => RebuildIndexCacheRefresher.UniqueId;
+
+    public RebuildIndexNotificationHandler(
+        DistributedCache distributedCache,
+        IOriginProvider originProvider,
+        IIndexDocumentService indexDocumentService)
+        : base(distributedCache, originProvider, indexDocumentService)
+    {
+    }
+
+    public void Handle(IEnumerable<string> indexAliases)
+    {
+        RebuildIndexCacheRefresher.JsonPayload[] payloads = indexAliases
+            .Select(indexAlias => new RebuildIndexCacheRefresher.JsonPayload(indexAlias))
+            .ToArray();
+
+        HandlePayloads(payloads);
+    }
+}

--- a/src/Umbraco.Cms.Search.Core/Controllers/RebuildIndexApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/RebuildIndexApiController.cs
@@ -1,9 +1,6 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Umbraco.Cms.Search.Core.Configuration;
-using Umbraco.Cms.Search.Core.Models.Configuration;
 using Umbraco.Cms.Search.Core.Services.ContentIndexing;
 
 namespace Umbraco.Cms.Search.Core.Controllers;
@@ -11,16 +8,10 @@ namespace Umbraco.Cms.Search.Core.Controllers;
 [ApiVersion("1.0")]
 public class RebuildIndexApiController : ApiControllerBase
 {
-    private readonly IContentIndexingService _contentIndexingService;
-    private readonly IndexOptions _options;
-    private readonly IOriginProvider _originProvider;
+    private readonly IDistributedContentIndexRebuilder _distributedContentIndexRebuilder;
 
-    public RebuildIndexApiController(IContentIndexingService contentIndexingService, IOptions<IndexOptions> options, IOriginProvider originProvider)
-    {
-        _contentIndexingService = contentIndexingService;
-        _originProvider = originProvider;
-        _options = options.Value;
-    }
+    public RebuildIndexApiController(IDistributedContentIndexRebuilder distributedContentIndexRebuilder)
+        => _distributedContentIndexRebuilder = distributedContentIndexRebuilder;
 
     [HttpPut("rebuild")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -33,14 +24,8 @@ public class RebuildIndexApiController : ApiControllerBase
             return BadRequest("The indexAlias parameter must be provided and cannot be empty.");
         }
 
-        // Check if the index exists before calling the service
-        ContentIndexRegistration? indexRegistration = _options.GetContentIndexRegistration(indexAlias);
-        if (indexRegistration is null)
-        {
-            return NotFound("The specified index alias was not found.");
-        }
-
-        _contentIndexingService.Rebuild(indexAlias, _originProvider.GetCurrent());
-        return Ok();
+        return _distributedContentIndexRebuilder.Rebuild(indexAlias)
+            ? Ok()
+            : BadRequest("Could not rebuild the index with the specified index alias. See the log for details.");
     }
 }

--- a/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Search.Core.Cache;
 using Umbraco.Cms.Search.Core.Notifications;
 using Umbraco.Cms.Search.Core.Cache.Content;
 using Umbraco.Cms.Search.Core.Cache.ContentType;
+using Umbraco.Cms.Search.Core.Cache.Index;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.Cache.Media;
 using Umbraco.Cms.Search.Core.Cache.MediaType;
@@ -62,13 +63,17 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddTransient<PublishedContentNotificationHandler>();
         builder.Services.AddTransient<DraftMediaNotificationHandler>();
         builder.Services.AddTransient<DraftMemberNotificationHandler>();
+
+        builder.Services.AddTransient<RebuildIndexNotificationHandler>();
         builder.Services.AddTransient<IDistributedContentIndexRefresher, DistributedContentIndexRefresher>();
+        builder.Services.AddTransient<IDistributedContentIndexRebuilder, DistributedContentIndexRebuilder>();
 
         builder
             .AddNotificationHandler<LanguageCacheRefresherNotification, RebuildIndexesNotificationHandler>()
             .AddNotificationHandler<ContentTypeCacheRefresherNotification, RebuildIndexesNotificationHandler>()
             .AddNotificationHandler<MemberTypeCacheRefresherNotification, RebuildIndexesNotificationHandler>()
             .AddNotificationHandler<MediaTypeCacheRefresherNotification, RebuildIndexesNotificationHandler>()
+            .AddNotificationHandler<RebuildIndexCacheRefresherNotification, RebuildIndexesNotificationHandler>()
             .AddNotificationAsyncHandler<IndexRebuildStartingNotification, IndexRebuildServerEventNotificationHandler>()
             .AddNotificationAsyncHandler<IndexRebuildCompletedNotification, IndexRebuildServerEventNotificationHandler>();
 

--- a/src/Umbraco.Cms.Search.Core/NotificationHandlers/RebuildIndexesNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/NotificationHandlers/RebuildIndexesNotificationHandler.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Cms.Search.Core.Cache.ContentType;
+using Umbraco.Cms.Search.Core.Cache.Index;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.Cache.MediaType;
 using Umbraco.Cms.Search.Core.Cache.MemberType;
@@ -19,7 +20,8 @@ internal sealed class RebuildIndexesNotificationHandler : IndexingNotificationHa
     INotificationHandler<LanguageCacheRefresherNotification>,
     INotificationHandler<ContentTypeCacheRefresherNotification>,
     INotificationHandler<MemberTypeCacheRefresherNotification>,
-    INotificationHandler<MediaTypeCacheRefresherNotification>
+    INotificationHandler<MediaTypeCacheRefresherNotification>,
+    INotificationHandler<RebuildIndexCacheRefresherNotification>
 {
     private readonly IContentIndexingService _contentIndexingService;
     private readonly IndexOptions _options;
@@ -70,6 +72,16 @@ internal sealed class RebuildIndexesNotificationHandler : IndexingNotificationHa
         MediaTypeCacheRefresher.JsonPayload[] payloads = GetNotificationPayloads<MediaTypeCacheRefresher.JsonPayload>(notification, out var origin);
 
         HandleContentTypeChanges(payloads.Select(payload => (payload.MediaTypeKey, payload.ChangeTypes)), UmbracoObjectTypes.Media, origin);
+    }
+
+    public void Handle(RebuildIndexCacheRefresherNotification notification)
+    {
+        RebuildIndexCacheRefresher.JsonPayload[] payloads = GetNotificationPayloads<RebuildIndexCacheRefresher.JsonPayload>(notification, out var origin);
+
+        foreach (RebuildIndexCacheRefresher.JsonPayload payload in payloads)
+        {
+            _contentIndexingService.Rebuild(payload.IndexAlias, origin);
+        }
     }
 
     private void HandleContentTypeChanges(IEnumerable<(Guid ContentTypeKey, ContentTypeChangeTypes ChangeTypes)> changes, UmbracoObjectTypes objectType, string origin)

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DistributedContentIndexRebuilder.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DistributedContentIndexRebuilder.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Search.Core.Cache.Index;
+using Umbraco.Cms.Search.Core.Configuration;
+
+namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
+
+internal sealed class DistributedContentIndexRebuilder : IDistributedContentIndexRebuilder
+{
+    private readonly RebuildIndexNotificationHandler _rebuildIndexNotificationHandler;
+    private readonly IndexOptions _options;
+    private readonly ILogger<DistributedContentIndexRebuilder> _logger;
+
+    public DistributedContentIndexRebuilder(
+        RebuildIndexNotificationHandler rebuildIndexNotificationHandler,
+        IOptions<IndexOptions> options,
+        ILogger<DistributedContentIndexRebuilder> logger)
+    {
+        _rebuildIndexNotificationHandler = rebuildIndexNotificationHandler;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public bool Rebuild(string indexAlias)
+    {
+        if (_options
+                .GetContentIndexRegistrations()
+                .Select(registration => registration.IndexAlias)
+                .Contains(indexAlias) is false)
+        {
+            _logger.LogError("No index registration found for index with alias: {indexAlias} - skipping the reindex operation.", indexAlias);
+            return false;
+        }
+
+        _rebuildIndexNotificationHandler.Handle([indexAlias]);
+        return true;
+    }
+}

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IDistributedContentIndexRebuilder.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IDistributedContentIndexRebuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Cms.Search.Core.Services.ContentIndexing;
+
+public interface IDistributedContentIndexRebuilder
+{
+    bool Rebuild(string indexAlias);
+}

--- a/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRebuilderTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/DistributedContentIndexRebuilderTests.cs
@@ -1,0 +1,128 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Test.Search.Integration.Tests;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerFixture)]
+public class DistributedContentIndexRebuilderTests : TestBase
+{
+    private bool _fixtureIsInitialized;
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
+
+    private IMediaService MediaService => GetRequiredService<IMediaService>();
+
+    private IMemberTypeService MemberTypeService => GetRequiredService<IMemberTypeService>();
+
+    private IMemberService MemberService => GetRequiredService<IMemberService>();
+
+    private IDistributedContentIndexRebuilder DistributedContentIndexRebuilder => GetRequiredService<IDistributedContentIndexRebuilder>();
+
+    [SetUp]
+    public async Task SetupTest()
+    {
+        // unfortunately, OneTimeSetUp won't work due to dependencies being setup in Umbraco test base classes,
+        // so this is a workaround :)
+        if (_fixtureIsInitialized)
+        {
+            return;
+        }
+
+        IContentType contentType = new ContentTypeBuilder()
+            .WithAlias("theContent")
+            .WithAllowAsRoot(true)
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        for (var i = 0; i < 5; i++)
+        {
+            IContent content = new ContentBuilder()
+                .WithContentType(contentType)
+                .WithName($"Content {i}")
+                .Build();
+            ContentService.Save(content);
+            ContentService.Publish(content, ["*"]);
+        }
+
+        IMediaType mediaType = MediaTypeService.Get("Folder")
+                               ?? throw new InvalidOperationException("Could not find the Folder media type");
+
+        for (var i = 0; i < 5; i++)
+        {
+            IMedia media = new MediaBuilder()
+                .WithMediaType(mediaType)
+                .WithName($"Media {i}")
+                .Build();
+            MediaService.Save(media);
+        }
+
+        IMemberType memberType = new MemberTypeBuilder()
+            .WithAlias("theMember")
+            .Build();
+
+        await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
+
+        for (var i = 0; i < 5; i++)
+        {
+            IMember member = new MemberBuilder()
+                .WithMemberType(memberType)
+                .WithName($"Member {i}")
+                .Build();
+            MemberService.Save(member);
+        }
+
+        IndexerAndSearcher.Reset();
+
+        _fixtureIsInitialized = true;
+    }
+
+    [Test]
+    public void RebuildDraftContent()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.DraftContent), Is.Empty);
+
+        DistributedContentIndexRebuilder.Rebuild(IndexAliases.DraftContent);
+
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.DraftContent).Count, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void RebuildPublishedContent()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.PublishedContent), Is.Empty);
+
+        DistributedContentIndexRebuilder.Rebuild(IndexAliases.PublishedContent);
+
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.PublishedContent).Count, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void RebuildMedia()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Media), Is.Empty);
+
+        DistributedContentIndexRebuilder.Rebuild(IndexAliases.Media);
+
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Media).Count, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void RebuildMember()
+    {
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Member), Is.Empty);
+
+        DistributedContentIndexRebuilder.Rebuild(IndexAliases.Member);
+
+        Assert.That(IndexerAndSearcher.Dump(IndexAliases.Member).Count, Is.EqualTo(5));
+    }
+}


### PR DESCRIPTION
A continuation of #99, this adds distributed content index rebuilding, to ensure that index rebuilds are triggered across all instances in a load balanced setup.

Note that providers can still opt into only handling indexing operations (rebuilds in this case) on the `origin` of the operation. This is applicable to out-of-process providers, where one definitively does _not_ want to perform index rebuilds on all instances.