### PR TITLE
Only delete some fields on language delete

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Cache/ContentNotificationHandlerBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/ContentNotificationHandlerBase.cs
@@ -42,7 +42,7 @@ internal abstract class ContentNotificationHandlerBase<TPayload>
         => _indexDocumentService.DeleteAllAsync().GetAwaiter().GetResult();
 
     protected void RemoveLanguageFromDocumentIndexCache(IReadOnlyCollection<string> isoCodes)
-        => _indexDocumentService.RemoveFieldsByCultureAsync(isoCodes).GetAwaiter().GetResult();
+        => _indexDocumentService.DeleteCulturesAsync(isoCodes).GetAwaiter().GetResult();
 
     protected void ClearDocumentIndexCacheForStructuralChanges(IEnumerable<ContentTypeChangeTypes> changes)
     {

--- a/src/Umbraco.Cms.Search.Core/Cache/ContentNotificationHandlerBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/ContentNotificationHandlerBase.cs
@@ -41,6 +41,9 @@ internal abstract class ContentNotificationHandlerBase<TPayload>
     protected void ClearDocumentIndexCache()
         => _indexDocumentService.DeleteAllAsync().GetAwaiter().GetResult();
 
+    protected void RemoveLanguageFromDocumentIndexCache(IReadOnlyCollection<string> isoCodes)
+        => _indexDocumentService.RemoveFieldsByCultureAsync(isoCodes).GetAwaiter().GetResult();
+
     protected void ClearDocumentIndexCacheForStructuralChanges(IEnumerable<ContentTypeChangeTypes> changes)
     {
         if (changes.Any(change => change.RequiresIndexRebuild()))

--- a/src/Umbraco.Cms.Search.Core/Cache/Language/LanguageNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/Cache/Language/LanguageNotificationHandler.cs
@@ -27,7 +27,8 @@ internal sealed class LanguageNotificationHandler
             return;
         }
 
-        ClearDocumentIndexCache();
+        string[] isoCodes = deletedEntities.Select(language => language.IsoCode).ToArray();
+        RemoveLanguageFromDocumentIndexCache(isoCodes);
 
         LanguageCacheRefresher.JsonPayload[] payloads = deletedEntities
             .Select(language => new LanguageCacheRefresher.JsonPayload(language.Key, language.IsoCode, LanguageChangeTypes.Delete))

--- a/src/Umbraco.Cms.Search.Core/Constants.cs
+++ b/src/Umbraco.Cms.Search.Core/Constants.cs
@@ -50,5 +50,7 @@ public static class Constants
     public static class Persistence
     {
         public const string IndexDocumentTableName = Umbraco.Cms.Core.Constants.DatabaseSchema.TableNamePrefix + "IndexDocument";
+
+        public const string IndexDocumentFieldsTableName = Umbraco.Cms.Core.Constants.DatabaseSchema.TableNamePrefix + "IndexDocumentFields";
     }
 }

--- a/src/Umbraco.Cms.Search.Core/Persistence/IIndexDocumentRepository.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IIndexDocumentRepository.cs
@@ -11,4 +11,6 @@ public interface IIndexDocumentRepository
     public Task DeleteAsync(Guid[] ids, bool published);
 
     public Task DeleteAllAsync();
+
+    public Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes);
 }

--- a/src/Umbraco.Cms.Search.Core/Persistence/IIndexDocumentRepository.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IIndexDocumentRepository.cs
@@ -12,5 +12,5 @@ public interface IIndexDocumentRepository
 
     public Task DeleteAllAsync();
 
-    public Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes);
+    public Task DeleteCulturesAsync(IReadOnlyCollection<string> isoCodes);
 }

--- a/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentDto.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentDto.cs
@@ -17,7 +17,4 @@ public class IndexDocumentDto
 
     [Column("published")]
     public required bool Published { get; set; }
-
-    [Column("fields")]
-    public required byte[] Fields { get; set; }
 }

--- a/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentFieldsDto.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentFieldsDto.cs
@@ -1,0 +1,25 @@
+using System.Data;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.Cms.Search.Core.Persistence;
+
+[TableName(Constants.Persistence.IndexDocumentFieldsTableName)]
+[PrimaryKey("id")]
+[ExplicitColumns]
+public class IndexDocumentFieldsDto
+{
+    [Column("id")]
+    [PrimaryKeyColumn(AutoIncrement = true)]
+    public int Id { get; set; }
+
+    [Column("indexDocumentId")]
+    [ForeignKey(typeof(IndexDocumentDto), OnDelete = Rule.Cascade)]
+    public required int IndexDocumentId { get; set; }
+
+    [Column("culture")]
+    public required string Culture { get; set; }
+
+    [Column("fields")]
+    public required byte[] Fields { get; set; }
+}

--- a/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentRepository.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentRepository.cs
@@ -142,7 +142,7 @@ public class IndexDocumentRepository : IIndexDocumentRepository
         await database.ExecuteAsync(sql);
     }
 
-    public async Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes)
+    public async Task DeleteCulturesAsync(IReadOnlyCollection<string> isoCodes)
     {
         ArgumentNullException.ThrowIfNull(_scopeAccessor.AmbientScope);
 

--- a/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentRepository.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentRepository.cs
@@ -1,4 +1,4 @@
-﻿using MessagePack;
+using MessagePack;
 using MessagePack.Resolvers;
 using NPoco;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -33,8 +33,33 @@ public class IndexDocumentRepository : IIndexDocumentRepository
             throw new InvalidOperationException("Cannot add document as there is no ambient scope.");
         }
 
-        IndexDocumentDto dto = ToDto(indexDocument);
-        await _scopeAccessor.AmbientScope.Database.InsertAsync(dto);
+        IUmbracoDatabase database = _scopeAccessor.AmbientScope.Database;
+
+        var parentDto = new IndexDocumentDto
+        {
+            Key = indexDocument.Key,
+            Published = indexDocument.Published,
+        };
+        await database.InsertAsync(parentDto);
+
+        IGrouping<string, IndexField>[] groups = indexDocument.Fields
+            .GroupBy(f => f.Culture ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (IGrouping<string, IndexField> group in groups)
+        {
+            IndexField[] fieldsForSerialization = group
+                .Select(f => f with { Culture = null })
+                .ToArray();
+
+            var childDto = new IndexDocumentFieldsDto
+            {
+                IndexDocumentId = parentDto.Id,
+                Culture = group.Key,
+                Fields = MessagePackSerializer.Serialize(fieldsForSerialization, _options),
+            };
+            await database.InsertAsync(childDto);
+        }
     }
 
     public async Task<IndexDocument?> GetAsync(Guid id, bool published)
@@ -44,14 +69,45 @@ public class IndexDocumentRepository : IIndexDocumentRepository
             throw new InvalidOperationException("Cannot get document as there is no ambient scope.");
         }
 
-        Sql<ISqlContext> sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql()
+        IUmbracoDatabase database = _scopeAccessor.AmbientScope.Database;
+
+        Sql<ISqlContext> parentSql = database.SqlContext.Sql()
             .Select<IndexDocumentDto>()
             .From<IndexDocumentDto>()
             .Where<IndexDocumentDto>(x => x.Key == id && x.Published == published);
 
-        IndexDocumentDto? documentDto = await _scopeAccessor.AmbientScope.Database.FirstOrDefaultAsync<IndexDocumentDto>(sql);
+        IndexDocumentDto? parentDto = await database.FirstOrDefaultAsync<IndexDocumentDto>(parentSql);
+        if (parentDto is null)
+        {
+            return null;
+        }
 
-        return ToDocument(documentDto);
+        Sql<ISqlContext> childSql = database.SqlContext.Sql()
+            .Select<IndexDocumentFieldsDto>()
+            .From<IndexDocumentFieldsDto>()
+            .Where<IndexDocumentFieldsDto>(x => x.IndexDocumentId == parentDto.Id);
+
+        List<IndexDocumentFieldsDto> childDtos = await database.FetchAsync<IndexDocumentFieldsDto>(childSql);
+
+        if (childDtos.Count == 0)
+        {
+            return null;
+        }
+
+        var allFields = new List<IndexField>();
+        foreach (IndexDocumentFieldsDto child in childDtos)
+        {
+            string? culture = child.Culture == string.Empty ? null : child.Culture;
+            IndexField[] fields = MessagePackSerializer.Deserialize<IndexField[]>(child.Fields, _options);
+            allFields.AddRange(fields.Select(f => f with { Culture = culture }));
+        }
+
+        return new IndexDocument
+        {
+            Key = parentDto.Key,
+            Published = parentDto.Published,
+            Fields = allFields.ToArray(),
+        };
     }
 
     public async Task DeleteAsync(Guid[] ids, bool published)
@@ -61,12 +117,14 @@ public class IndexDocumentRepository : IIndexDocumentRepository
             throw new InvalidOperationException("Cannot delete document as there is no ambient scope.");
         }
 
+        IUmbracoDatabase database = _scopeAccessor.AmbientScope.Database;
         List<Guid> idsAsList = [..ids];
-        Sql<ISqlContext> sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql()
+
+        Sql<ISqlContext> sql = database.SqlContext.Sql()
             .Delete<IndexDocumentDto>()
             .Where<IndexDocumentDto>(x => idsAsList.Contains(x.Key) && x.Published == published);
 
-        await _scopeAccessor.AmbientScope.Database.ExecuteAsync(sql);
+        await database.ExecuteAsync(sql);
     }
 
     public async Task DeleteAllAsync()
@@ -76,64 +134,45 @@ public class IndexDocumentRepository : IIndexDocumentRepository
             throw new InvalidOperationException("Cannot delete all documents as there is no ambient scope.");
         }
 
-        Sql<ISqlContext> sql = _scopeAccessor.AmbientScope.Database.SqlContext.Sql()
+        IUmbracoDatabase database = _scopeAccessor.AmbientScope.Database;
+
+        Sql<ISqlContext> sql = database.SqlContext.Sql()
             .Delete<IndexDocumentDto>();
 
-        await _scopeAccessor.AmbientScope.Database.ExecuteAsync(sql);
+        await database.ExecuteAsync(sql);
     }
 
     public async Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes)
     {
         ArgumentNullException.ThrowIfNull(_scopeAccessor.AmbientScope);
 
-        var isoCodeSet = new HashSet<string>(isoCodes, StringComparer.OrdinalIgnoreCase);
         IUmbracoDatabase database = _scopeAccessor.AmbientScope.Database;
+        var isoCodesList = isoCodes.ToList();
 
-        Sql<ISqlContext> sql = database.SqlContext.Sql()
+        Sql<ISqlContext> deleteSql = database.SqlContext.Sql()
+            .Delete<IndexDocumentFieldsDto>()
+            .Where<IndexDocumentFieldsDto>(x => isoCodesList.Contains(x.Culture));
+
+        await database.ExecuteAsync(deleteSql);
+
+        // Clean up orphan parents that no longer have any child rows
+        Sql<ISqlContext> orphanSql = database.SqlContext.Sql()
             .Select<IndexDocumentDto>()
-            .From<IndexDocumentDto>();
+            .From<IndexDocumentDto>()
+            .LeftJoin<IndexDocumentFieldsDto>()
+            .On<IndexDocumentDto, IndexDocumentFieldsDto>(
+                (parent, child) => parent.Id == child.IndexDocumentId)
+            .Where<IndexDocumentFieldsDto>(x => x.Id == null!);
 
-        List<IndexDocumentDto> allDtos = await database.FetchAsync<IndexDocumentDto>(sql);
+        List<IndexDocumentDto> orphans = await database.FetchAsync<IndexDocumentDto>(orphanSql);
 
-        var idsToDelete = allDtos
-            .Where(dto =>
-            {
-                IndexField[] fields = MessagePackSerializer.Deserialize<IndexField[]>(dto.Fields, _options) ?? [];
-                return fields.Any(f => f.Culture is not null && isoCodeSet.Contains(f.Culture));
-            })
-            .Select(dto => dto.Id)
-            .ToList();
-
-        if (idsToDelete.Count > 0)
+        if (orphans.Count > 0)
         {
-            Sql<ISqlContext> deleteSql = database.SqlContext.Sql()
+            List<int> orphanIds = orphans.Select(x => x.Id).ToList();
+            Sql<ISqlContext> deleteOrphansSql = database.SqlContext.Sql()
                 .Delete<IndexDocumentDto>()
-                .Where<IndexDocumentDto>(x => idsToDelete.Contains(x.Id));
-
-            await database.ExecuteAsync(deleteSql);
+                .Where<IndexDocumentDto>(x => orphanIds.Contains(x.Id));
+            await database.ExecuteAsync(deleteOrphansSql);
         }
-    }
-
-    private IndexDocumentDto ToDto(IndexDocument indexDocument) =>
-        new()
-        {
-            Key = indexDocument.Key,
-            Published = indexDocument.Published,
-            Fields = MessagePackSerializer.Serialize(indexDocument.Fields, _options),
-        };
-
-    private IndexDocument? ToDocument(IndexDocumentDto? dto)
-    {
-        if (dto is null)
-        {
-            return null;
-        }
-
-        return new IndexDocument
-        {
-            Key = dto.Key,
-            Fields = MessagePackSerializer.Deserialize<IndexField[]>(dto.Fields, _options) ?? [],
-            Published = dto.Published,
-        };
     }
 }

--- a/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentRepository.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/IndexDocumentRepository.cs
@@ -82,6 +82,37 @@ public class IndexDocumentRepository : IIndexDocumentRepository
         await _scopeAccessor.AmbientScope.Database.ExecuteAsync(sql);
     }
 
+    public async Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes)
+    {
+        ArgumentNullException.ThrowIfNull(_scopeAccessor.AmbientScope);
+
+        var isoCodeSet = new HashSet<string>(isoCodes, StringComparer.OrdinalIgnoreCase);
+        IUmbracoDatabase database = _scopeAccessor.AmbientScope.Database;
+
+        Sql<ISqlContext> sql = database.SqlContext.Sql()
+            .Select<IndexDocumentDto>()
+            .From<IndexDocumentDto>();
+
+        List<IndexDocumentDto> allDtos = await database.FetchAsync<IndexDocumentDto>(sql);
+
+        var idsToDelete = allDtos
+            .Where(dto =>
+            {
+                IndexField[] fields = MessagePackSerializer.Deserialize<IndexField[]>(dto.Fields, _options) ?? [];
+                return fields.Any(f => f.Culture is not null && isoCodeSet.Contains(f.Culture));
+            })
+            .Select(dto => dto.Id)
+            .ToList();
+
+        if (idsToDelete.Count > 0)
+        {
+            Sql<ISqlContext> deleteSql = database.SqlContext.Sql()
+                .Delete<IndexDocumentDto>()
+                .Where<IndexDocumentDto>(x => idsToDelete.Contains(x.Id));
+
+            await database.ExecuteAsync(deleteSql);
+        }
+    }
 
     private IndexDocumentDto ToDto(IndexDocument indexDocument) =>
         new()

--- a/src/Umbraco.Cms.Search.Core/Persistence/Migration/AddIndexDocumentFieldsTableMigration.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/Migration/AddIndexDocumentFieldsTableMigration.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Packaging;
+
+namespace Umbraco.Cms.Search.Core.Persistence.Migration;
+
+public class AddIndexDocumentFieldsTableMigration : AsyncPackageMigrationBase
+{
+    public AddIndexDocumentFieldsTableMigration(
+        IPackagingService packagingService,
+        IMediaService mediaService,
+        MediaFileManager mediaFileManager,
+        MediaUrlGeneratorCollection mediaUrlGenerators,
+        IShortStringHelper shortStringHelper,
+        IContentTypeBaseServiceProvider contentTypeBaseServiceProvider,
+        IMigrationContext context,
+        IOptions<PackageMigrationSettings> packageMigrationsSettings)
+        : base(
+            packagingService,
+            mediaService,
+            mediaFileManager,
+            mediaUrlGenerators,
+            shortStringHelper,
+            contentTypeBaseServiceProvider,
+            context,
+            packageMigrationsSettings)
+    {
+    }
+
+    protected override Task MigrateAsync()
+    {
+        if (TableExists(Constants.Persistence.IndexDocumentFieldsTableName) == false)
+        {
+            Create.Table<IndexDocumentFieldsDto>().Do();
+        }
+
+        if (ColumnExists(Constants.Persistence.IndexDocumentTableName, "fields"))
+        {
+            Delete.FromTable(Constants.Persistence.IndexDocumentTableName).AllRows().Do();
+            Delete.Column("fields").FromTable(Constants.Persistence.IndexDocumentTableName).Do();
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Cms.Search.Core/Persistence/Migration/CustomMigrationPlan.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/Migration/CustomMigrationPlan.cs
@@ -11,5 +11,6 @@ public class CustomPackageMigrationPlan : PackageMigrationPlan
     protected override void DefinePlan()
     {
         To<CustomPackageMigration>(new Guid("4FD681BE-E27E-4688-922B-29EDCDCB8A49"));
+        To<AddIndexDocumentFieldsTableMigration>(new Guid("A1B2C3D4-E5F6-7890-ABCD-EF1234567890"));
     }
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IIndexDocumentService.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IIndexDocumentService.cs
@@ -12,5 +12,5 @@ public interface IIndexDocumentService
 
     Task DeleteAllAsync();
 
-    Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes);
+    Task DeleteCulturesAsync(IReadOnlyCollection<string> isoCodes);
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IIndexDocumentService.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IIndexDocumentService.cs
@@ -11,4 +11,6 @@ public interface IIndexDocumentService
     Task<IndexDocument?> GetAsync(Guid id, bool published);
 
     Task DeleteAllAsync();
+
+    Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes);
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IndexDocumentService.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IndexDocumentService.cs
@@ -45,10 +45,10 @@ public class IndexDocumentService : IIndexDocumentService
         scope.Complete();
     }
 
-    public async Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes)
+    public async Task DeleteCulturesAsync(IReadOnlyCollection<string> isoCodes)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        await _indexDocumentRepository.RemoveFieldsByCultureAsync(isoCodes);
+        await _indexDocumentRepository.DeleteCulturesAsync(isoCodes);
         scope.Complete();
     }
 }

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IndexDocumentService.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/IndexDocumentService.cs
@@ -44,4 +44,11 @@ public class IndexDocumentService : IIndexDocumentService
         await _indexDocumentRepository.DeleteAllAsync();
         scope.Complete();
     }
+
+    public async Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes)
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        await _indexDocumentRepository.RemoveFieldsByCultureAsync(isoCodes);
+        scope.Complete();
+    }
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/DeleteCulturesTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/DeleteCulturesTests.cs
@@ -13,7 +13,7 @@ using Umbraco.Cms.Tests.Common.Builders.Extensions;
 namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.PersistenceTests;
 
 [TestFixture]
-public class RemoveFieldsByCultureTests : TestBase
+public class DeleteCulturesTests : TestBase
 {
     private IIndexDocumentRepository IndexDocumentRepository => GetRequiredService<IIndexDocumentRepository>();
 
@@ -31,7 +31,7 @@ public class RemoveFieldsByCultureTests : TestBase
         }
 
         await LanguageService.DeleteAsync("da-DK", Constants.Security.SuperUserKey);
-        await Task.Delay(4000);
+        await WaitForUpdatesAsync();
 
         using (ScopeProvider.CreateScope(autoComplete: true))
         {
@@ -58,7 +58,7 @@ public class RemoveFieldsByCultureTests : TestBase
         }
 
         await LanguageService.DeleteAsync("da-DK", Constants.Security.SuperUserKey);
-        await Task.Delay(4000);
+        await WaitForUpdatesAsync();
 
         using (ScopeProvider.CreateScope(autoComplete: true))
         {
@@ -86,7 +86,7 @@ public class RemoveFieldsByCultureTests : TestBase
 
         // Delete ja-JP only; en-US and fr-FR should remain
         await LanguageService.DeleteAsync("ja-JP", Constants.Security.SuperUserKey);
-        await Task.Delay(4000);
+        await WaitForUpdatesAsync();
 
         using (ScopeProvider.CreateScope(autoComplete: true))
         {
@@ -98,7 +98,7 @@ public class RemoveFieldsByCultureTests : TestBase
     }
 
     [Test]
-    public async Task RemoveFieldsByCulture_CleansUpOrphanParentRows()
+    public async Task DeleteCultures_CleansUpOrphanParentRows()
     {
         await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
 
@@ -136,7 +136,7 @@ public class RemoveFieldsByCultureTests : TestBase
         // Remove the only culture, which should also clean up the orphan parent
         using (ScopeProvider.CreateScope(autoComplete: true))
         {
-            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
+            await IndexDocumentRepository.DeleteCulturesAsync(["da-DK"]);
         }
 
         // Verify the parent row is gone (not just that GetAsync returns null)
@@ -342,4 +342,6 @@ public class RemoveFieldsByCultureTests : TestBase
             return Task.CompletedTask;
         });
     }
+
+    private static async Task WaitForUpdatesAsync() => await Task.Delay(4000);
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RemoveFieldsByCultureTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RemoveFieldsByCultureTests.cs
@@ -1,0 +1,315 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Search.Core.Models.Indexing;
+using Umbraco.Cms.Search.Core.Models.Persistence;
+using Umbraco.Cms.Search.Core.Persistence;
+using Umbraco.Cms.Search.Core.Services.ContentIndexing;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.PersistenceTests;
+
+[TestFixture]
+public class RemoveFieldsByCultureTests : TestBase
+{
+    private IIndexDocumentRepository IndexDocumentRepository => GetRequiredService<IIndexDocumentRepository>();
+
+    private IContentIndexingService ContentIndexingService => GetRequiredService<IContentIndexingService>();
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task RemoveFieldsByCulture_RemovesDocumentsWithMatchingCulture(bool publish)
+    {
+        await CreateVariantContent(publish);
+
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(doc, Is.Not.Null);
+            Assert.That(doc!.Fields.Any(f => f.Culture == "da-DK"), Is.True);
+
+            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
+
+            IndexDocument? docAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(docAfter, Is.Null, "Document with fields for the deleted culture should be removed from cache");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task RemoveFieldsByCulture_PreservesInvariantOnlyDocuments(bool publish)
+    {
+        await CreateInvariantAndVariantContent(publish);
+
+        Guid invariantKey;
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            // Both documents should exist
+            IndexDocument? variantDoc = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(variantDoc, Is.Not.Null);
+
+            invariantKey = ChildKey;
+            IndexDocument? invariantDoc = await IndexDocumentRepository.GetAsync(invariantKey, publish);
+            Assert.That(invariantDoc, Is.Not.Null);
+            Assert.That(invariantDoc!.Fields.All(f => f.Culture is null), Is.True, "Invariant document should have no culture-specific fields");
+
+            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
+
+            // Variant document should be removed (it had da-DK fields)
+            IndexDocument? variantDocAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(variantDocAfter, Is.Null, "Variant document should be removed from cache");
+
+            // Invariant document should be preserved (no culture-specific fields)
+            IndexDocument? invariantDocAfter = await IndexDocumentRepository.GetAsync(invariantKey, publish);
+            Assert.That(invariantDocAfter, Is.Not.Null, "Invariant document should be preserved in cache");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task RemoveFieldsByCulture_RebuildRecreatesDocumentsFromContent(bool publish)
+    {
+        await CreateVariantContent(publish);
+        var indexAlias = GetIndexAlias(publish);
+
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(doc, Is.Not.Null);
+
+            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
+
+            IndexDocument? docAfterRemove = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(docAfterRemove, Is.Null);
+        }
+
+        // Rebuild should re-collect the document (without the deleted language, since
+        // the language no longer exists in the system at that point - but for this test
+        // the language still exists, so all cultures will be re-collected)
+        ContentIndexingService.Rebuild(indexAlias, DefaultOrigin);
+
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IndexDocument? docAfterRebuild = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(docAfterRebuild, Is.Not.Null, "Document should be re-created after rebuild");
+            Assert.That(docAfterRebuild!.Fields.Length, Is.GreaterThan(0));
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task RemoveFieldsByCulture_MultipleIsoCodes_RemovesAllMatching(bool publish)
+    {
+        await CreateVariantContent(publish);
+
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(doc, Is.Not.Null);
+            Assert.That(doc!.Fields.Any(f => f.Culture == "da-DK"), Is.True);
+            Assert.That(doc.Fields.Any(f => f.Culture == "ja-JP"), Is.True);
+
+            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK", "ja-JP"]);
+
+            IndexDocument? docAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(docAfter, Is.Null, "Document with fields for any deleted culture should be removed from cache");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task DeletingLanguage_RemovesVariantDocumentsFromCache_ButPreservesInvariant(bool publish)
+    {
+        await CreateInvariantAndVariantContent(publish);
+
+        IndexField[] invariantFieldsBefore;
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            // Both documents should exist in cache before language deletion
+            IndexDocument? variantDoc = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(variantDoc, Is.Not.Null, "Variant document should be in cache before language deletion");
+
+            IndexDocument? invariantDoc = await IndexDocumentRepository.GetAsync(ChildKey, publish);
+            Assert.That(invariantDoc, Is.Not.Null, "Invariant document should be in cache before language deletion");
+            invariantFieldsBefore = invariantDoc!.Fields;
+        }
+
+        // Delete the language through the service - this triggers the full notification pipeline:
+        // LanguageDeletedNotification -> LanguageNotificationHandler -> RemoveFieldsByCultureAsync
+        await LanguageService.DeleteAsync("da-DK", Cms.Core.Constants.Security.SuperUserKey);
+
+        // Allow background rebuild to complete
+        await Task.Delay(4000);
+
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            // The invariant document should still be in cache with the same fields (not wiped by the
+            // language deletion). This is the key assertion - previously, ClearDocumentIndexCache()
+            // would have wiped it too, forcing an expensive re-collection from content services.
+            IndexDocument? invariantDocAfter = await IndexDocumentRepository.GetAsync(ChildKey, publish);
+            Assert.That(invariantDocAfter, Is.Not.Null, "Invariant document cache should be preserved after language deletion");
+            Assert.That(invariantDocAfter!.Fields.Length, Is.EqualTo(invariantFieldsBefore.Length), "Invariant document fields should be unchanged");
+
+            // The variant document should be re-created by the rebuild
+            IndexDocument? variantDocAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(variantDocAfter, Is.Not.Null, "Variant document should be re-created by rebuild");
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task RemoveFieldsByCulture_NonMatchingCulture_PreservesDocument(bool publish)
+    {
+        await CreateVariantContent(publish);
+
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(doc, Is.Not.Null);
+            var originalFieldCount = doc!.Fields.Length;
+
+            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["fr-FR"]);
+
+            IndexDocument? docAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
+            Assert.That(docAfter, Is.Not.Null, "Document should be preserved when no fields match the deleted culture");
+            Assert.That(docAfter!.Fields.Length, Is.EqualTo(originalFieldCount));
+        }
+    }
+
+    private async Task CreateVariantContent(bool publish)
+    {
+        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
+        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+
+        ILanguage langDk = new LanguageBuilder()
+            .WithCultureInfo("da-DK")
+            .WithIsDefault(true)
+            .Build();
+        ILanguage langJp = new LanguageBuilder()
+            .WithCultureInfo("ja-JP")
+            .Build();
+
+        await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langJp, Cms.Core.Constants.Security.SuperUserKey);
+
+        IContentType contentType = new ContentTypeBuilder()
+            .WithAlias("variantType")
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyType()
+                .WithAlias("title")
+                .WithVariations(ContentVariation.Culture)
+                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .Done()
+            .Build();
+        ContentTypeService.Save(contentType);
+
+        Content root = new ContentBuilder()
+            .WithKey(RootKey)
+            .WithContentType(contentType)
+            .WithCultureName("en-US", "Root EN")
+            .WithCultureName("da-DK", "Root DA")
+            .WithCultureName("ja-JP", "Root JP")
+            .Build();
+
+        root.SetValue("title", "English Title", "en-US");
+        root.SetValue("title", "Danish Title", "da-DK");
+        root.SetValue("title", "Japanese Title", "ja-JP");
+
+        var indexAlias = GetIndexAlias(publish);
+        await WaitForIndexing(indexAlias, () =>
+        {
+            ContentService.Save(root);
+            if (publish)
+            {
+                ContentService.Publish(root, ["*"]);
+            }
+
+            return Task.CompletedTask;
+        });
+    }
+
+    private async Task CreateInvariantAndVariantContent(bool publish)
+    {
+        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
+        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+
+        ILanguage langDk = new LanguageBuilder()
+            .WithCultureInfo("da-DK")
+            .WithIsDefault(true)
+            .Build();
+
+        await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);
+
+        // Variant content type
+        IContentType variantType = new ContentTypeBuilder()
+            .WithAlias("variantType")
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyType()
+                .WithAlias("title")
+                .WithVariations(ContentVariation.Culture)
+                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .Done()
+            .Build();
+        ContentTypeService.Save(variantType);
+
+        // Invariant content type
+        IContentType invariantType = new ContentTypeBuilder()
+            .WithAlias("invariantType")
+            .WithContentVariation(ContentVariation.Nothing)
+            .AddPropertyType()
+                .WithAlias("title")
+                .WithVariations(ContentVariation.Nothing)
+                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .Done()
+            .Build();
+        ContentTypeService.Save(invariantType);
+
+        var indexAlias = GetIndexAlias(publish);
+
+        // Create variant content
+        Content variantRoot = new ContentBuilder()
+            .WithKey(RootKey)
+            .WithContentType(variantType)
+            .WithCultureName("en-US", "Variant EN")
+            .WithCultureName("da-DK", "Variant DA")
+            .Build();
+
+        variantRoot.SetValue("title", "English Title", "en-US");
+        variantRoot.SetValue("title", "Danish Title", "da-DK");
+
+        await WaitForIndexing(indexAlias, () =>
+        {
+            ContentService.Save(variantRoot);
+            if (publish)
+            {
+                ContentService.Publish(variantRoot, ["*"]);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        // Create invariant content
+        Content invariantRoot = new ContentBuilder()
+            .WithKey(ChildKey)
+            .WithContentType(invariantType)
+            .Build();
+
+        invariantRoot.Name = "Invariant Content";
+        invariantRoot.SetValue("title", "Invariant Title");
+
+        await WaitForIndexing(indexAlias, () =>
+        {
+            ContentService.Save(invariantRoot);
+            if (publish)
+            {
+                ContentService.Publish(invariantRoot, ["*"]);
+            }
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RemoveFieldsByCultureTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RemoveFieldsByCultureTests.cs
@@ -4,7 +4,6 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Core.Models.Indexing;
 using Umbraco.Cms.Search.Core.Models.Persistence;
 using Umbraco.Cms.Search.Core.Persistence;
-using Umbraco.Cms.Search.Core.Services.ContentIndexing;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 
@@ -15,11 +14,9 @@ public class RemoveFieldsByCultureTests : TestBase
 {
     private IIndexDocumentRepository IndexDocumentRepository => GetRequiredService<IIndexDocumentRepository>();
 
-    private IContentIndexingService ContentIndexingService => GetRequiredService<IContentIndexingService>();
-
     [TestCase(true)]
     [TestCase(false)]
-    public async Task RemoveFieldsByCulture_RemovesDocumentsWithMatchingCulture(bool publish)
+    public async Task DeletingLanguage_RemovesVariantDocumentFromCache(bool publish)
     {
         await CreateVariantContent(publish);
 
@@ -28,118 +25,36 @@ public class RemoveFieldsByCultureTests : TestBase
             IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
             Assert.That(doc, Is.Not.Null);
             Assert.That(doc!.Fields.Any(f => f.Culture == "da-DK"), Is.True);
+        }
 
-            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
+        await LanguageService.DeleteAsync("da-DK", Cms.Core.Constants.Security.SuperUserKey);
+        await Task.Delay(4000);
 
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            // The variant document should be re-created by the rebuild (without the deleted culture's fields,
+            // since the language no longer exists in the system)
             IndexDocument? docAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(docAfter, Is.Null, "Document with fields for the deleted culture should be removed from cache");
+            Assert.That(docAfter, Is.Not.Null, "Document should be re-created by rebuild");
+            Assert.That(docAfter!.Fields.Any(f => f.Culture == "da-DK"), Is.False, "Deleted culture fields should not be present after rebuild");
         }
     }
 
     [TestCase(true)]
     [TestCase(false)]
-    public async Task RemoveFieldsByCulture_PreservesInvariantOnlyDocuments(bool publish)
-    {
-        await CreateInvariantAndVariantContent(publish);
-
-        Guid invariantKey;
-        using (ScopeProvider.CreateScope(autoComplete: true))
-        {
-            // Both documents should exist
-            IndexDocument? variantDoc = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(variantDoc, Is.Not.Null);
-
-            invariantKey = ChildKey;
-            IndexDocument? invariantDoc = await IndexDocumentRepository.GetAsync(invariantKey, publish);
-            Assert.That(invariantDoc, Is.Not.Null);
-            Assert.That(invariantDoc!.Fields.All(f => f.Culture is null), Is.True, "Invariant document should have no culture-specific fields");
-
-            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
-
-            // Variant document should be removed (it had da-DK fields)
-            IndexDocument? variantDocAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(variantDocAfter, Is.Null, "Variant document should be removed from cache");
-
-            // Invariant document should be preserved (no culture-specific fields)
-            IndexDocument? invariantDocAfter = await IndexDocumentRepository.GetAsync(invariantKey, publish);
-            Assert.That(invariantDocAfter, Is.Not.Null, "Invariant document should be preserved in cache");
-        }
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task RemoveFieldsByCulture_RebuildRecreatesDocumentsFromContent(bool publish)
-    {
-        await CreateVariantContent(publish);
-        var indexAlias = GetIndexAlias(publish);
-
-        using (ScopeProvider.CreateScope(autoComplete: true))
-        {
-            IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(doc, Is.Not.Null);
-
-            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
-
-            IndexDocument? docAfterRemove = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(docAfterRemove, Is.Null);
-        }
-
-        // Rebuild should re-collect the document (without the deleted language, since
-        // the language no longer exists in the system at that point - but for this test
-        // the language still exists, so all cultures will be re-collected)
-        ContentIndexingService.Rebuild(indexAlias, DefaultOrigin);
-
-        using (ScopeProvider.CreateScope(autoComplete: true))
-        {
-            IndexDocument? docAfterRebuild = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(docAfterRebuild, Is.Not.Null, "Document should be re-created after rebuild");
-            Assert.That(docAfterRebuild!.Fields.Length, Is.GreaterThan(0));
-        }
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task RemoveFieldsByCulture_MultipleIsoCodes_RemovesAllMatching(bool publish)
-    {
-        await CreateVariantContent(publish);
-
-        using (ScopeProvider.CreateScope(autoComplete: true))
-        {
-            IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(doc, Is.Not.Null);
-            Assert.That(doc!.Fields.Any(f => f.Culture == "da-DK"), Is.True);
-            Assert.That(doc.Fields.Any(f => f.Culture == "ja-JP"), Is.True);
-
-            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK", "ja-JP"]);
-
-            IndexDocument? docAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(docAfter, Is.Null, "Document with fields for any deleted culture should be removed from cache");
-        }
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task DeletingLanguage_RemovesVariantDocumentsFromCache_ButPreservesInvariant(bool publish)
+    public async Task DeletingLanguage_PreservesInvariantDocumentCache(bool publish)
     {
         await CreateInvariantAndVariantContent(publish);
 
         IndexField[] invariantFieldsBefore;
         using (ScopeProvider.CreateScope(autoComplete: true))
         {
-            // Both documents should exist in cache before language deletion
-            IndexDocument? variantDoc = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(variantDoc, Is.Not.Null, "Variant document should be in cache before language deletion");
-
             IndexDocument? invariantDoc = await IndexDocumentRepository.GetAsync(ChildKey, publish);
-            Assert.That(invariantDoc, Is.Not.Null, "Invariant document should be in cache before language deletion");
+            Assert.That(invariantDoc, Is.Not.Null);
             invariantFieldsBefore = invariantDoc!.Fields;
         }
 
-        // Delete the language through the service - this triggers the full notification pipeline:
-        // LanguageDeletedNotification -> LanguageNotificationHandler -> RemoveFieldsByCultureAsync
         await LanguageService.DeleteAsync("da-DK", Cms.Core.Constants.Security.SuperUserKey);
-
-        // Allow background rebuild to complete
         await Task.Delay(4000);
 
         using (ScopeProvider.CreateScope(autoComplete: true))
@@ -150,30 +65,32 @@ public class RemoveFieldsByCultureTests : TestBase
             IndexDocument? invariantDocAfter = await IndexDocumentRepository.GetAsync(ChildKey, publish);
             Assert.That(invariantDocAfter, Is.Not.Null, "Invariant document cache should be preserved after language deletion");
             Assert.That(invariantDocAfter!.Fields.Length, Is.EqualTo(invariantFieldsBefore.Length), "Invariant document fields should be unchanged");
-
-            // The variant document should be re-created by the rebuild
-            IndexDocument? variantDocAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(variantDocAfter, Is.Not.Null, "Variant document should be re-created by rebuild");
         }
     }
 
     [TestCase(true)]
     [TestCase(false)]
-    public async Task RemoveFieldsByCulture_NonMatchingCulture_PreservesDocument(bool publish)
+    public async Task DeletingLanguage_PreservesDocumentCacheForNonDeletedCultures(bool publish)
     {
-        await CreateVariantContent(publish);
+        await CreateVariantContentWithThreeCultures(publish);
 
         using (ScopeProvider.CreateScope(autoComplete: true))
         {
             IndexDocument? doc = await IndexDocumentRepository.GetAsync(RootKey, publish);
             Assert.That(doc, Is.Not.Null);
-            var originalFieldCount = doc!.Fields.Length;
+            Assert.That(doc!.Fields.Any(f => f.Culture == "fr-FR"), Is.True);
+        }
 
-            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["fr-FR"]);
+        // Delete ja-JP only; en-US and fr-FR should remain
+        await LanguageService.DeleteAsync("ja-JP", Cms.Core.Constants.Security.SuperUserKey);
+        await Task.Delay(4000);
 
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
             IndexDocument? docAfter = await IndexDocumentRepository.GetAsync(RootKey, publish);
-            Assert.That(docAfter, Is.Not.Null, "Document should be preserved when no fields match the deleted culture");
-            Assert.That(docAfter!.Fields.Length, Is.EqualTo(originalFieldCount));
+            Assert.That(docAfter, Is.Not.Null, "Document should be re-created by rebuild");
+            Assert.That(docAfter!.Fields.Any(f => f.Culture == "ja-JP"), Is.False, "Deleted culture fields should not be present after rebuild");
+            Assert.That(docAfter.Fields.Any(f => f.Culture == "fr-FR"), Is.True, "Non-deleted culture fields should still be present");
         }
     }
 
@@ -184,7 +101,6 @@ public class RemoveFieldsByCultureTests : TestBase
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
-            .WithIsDefault(true)
             .Build();
         ILanguage langJp = new LanguageBuilder()
             .WithCultureInfo("ja-JP")
@@ -230,6 +146,64 @@ public class RemoveFieldsByCultureTests : TestBase
         });
     }
 
+    private async Task CreateVariantContentWithThreeCultures(bool publish)
+    {
+        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
+        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+
+        ILanguage langDk = new LanguageBuilder()
+            .WithCultureInfo("da-DK")
+            .Build();
+        ILanguage langJp = new LanguageBuilder()
+            .WithCultureInfo("ja-JP")
+            .Build();
+        ILanguage langFr = new LanguageBuilder()
+            .WithCultureInfo("fr-FR")
+            .Build();
+
+        await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langJp, Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langFr, Cms.Core.Constants.Security.SuperUserKey);
+
+        IContentType contentType = new ContentTypeBuilder()
+            .WithAlias("variantType")
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyType()
+                .WithAlias("title")
+                .WithVariations(ContentVariation.Culture)
+                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .Done()
+            .Build();
+        ContentTypeService.Save(contentType);
+
+        Content root = new ContentBuilder()
+            .WithKey(RootKey)
+            .WithContentType(contentType)
+            .WithCultureName("en-US", "Root EN")
+            .WithCultureName("da-DK", "Root DA")
+            .WithCultureName("ja-JP", "Root JP")
+            .WithCultureName("fr-FR", "Root FR")
+            .Build();
+
+        root.SetValue("title", "English Title", "en-US");
+        root.SetValue("title", "Danish Title", "da-DK");
+        root.SetValue("title", "Japanese Title", "ja-JP");
+        root.SetValue("title", "French Title", "fr-FR");
+
+        var indexAlias = GetIndexAlias(publish);
+        await WaitForIndexing(indexAlias, () =>
+        {
+            ContentService.Save(root);
+            if (publish)
+            {
+                ContentService.Publish(root, ["*"]);
+            }
+
+            return Task.CompletedTask;
+        });
+    }
+
     private async Task CreateInvariantAndVariantContent(bool publish)
     {
         await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
@@ -237,7 +211,6 @@ public class RemoveFieldsByCultureTests : TestBase
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
-            .WithIsDefault(true)
             .Build();
 
         await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RemoveFieldsByCultureTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RemoveFieldsByCultureTests.cs
@@ -1,6 +1,9 @@
+using NPoco;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Search.Core.Models.Indexing;
 using Umbraco.Cms.Search.Core.Models.Persistence;
 using Umbraco.Cms.Search.Core.Persistence;
@@ -27,7 +30,7 @@ public class RemoveFieldsByCultureTests : TestBase
             Assert.That(doc!.Fields.Any(f => f.Culture == "da-DK"), Is.True);
         }
 
-        await LanguageService.DeleteAsync("da-DK", Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.DeleteAsync("da-DK", Constants.Security.SuperUserKey);
         await Task.Delay(4000);
 
         using (ScopeProvider.CreateScope(autoComplete: true))
@@ -54,7 +57,7 @@ public class RemoveFieldsByCultureTests : TestBase
             invariantFieldsBefore = invariantDoc!.Fields;
         }
 
-        await LanguageService.DeleteAsync("da-DK", Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.DeleteAsync("da-DK", Constants.Security.SuperUserKey);
         await Task.Delay(4000);
 
         using (ScopeProvider.CreateScope(autoComplete: true))
@@ -82,7 +85,7 @@ public class RemoveFieldsByCultureTests : TestBase
         }
 
         // Delete ja-JP only; en-US and fr-FR should remain
-        await LanguageService.DeleteAsync("ja-JP", Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.DeleteAsync("ja-JP", Constants.Security.SuperUserKey);
         await Task.Delay(4000);
 
         using (ScopeProvider.CreateScope(autoComplete: true))
@@ -91,6 +94,60 @@ public class RemoveFieldsByCultureTests : TestBase
             Assert.That(docAfter, Is.Not.Null, "Document should be re-created by rebuild");
             Assert.That(docAfter!.Fields.Any(f => f.Culture == "ja-JP"), Is.False, "Deleted culture fields should not be present after rebuild");
             Assert.That(docAfter.Fields.Any(f => f.Culture == "fr-FR"), Is.True, "Non-deleted culture fields should still be present");
+        }
+    }
+
+    [Test]
+    public async Task RemoveFieldsByCulture_CleansUpOrphanParentRows()
+    {
+        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
+
+        var documentKey = Guid.NewGuid();
+
+        // Insert a document that only has culture-specific fields (no invariant)
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            var document = new IndexDocument
+            {
+                Key = documentKey,
+                Published = false,
+                Fields =
+                [
+                    new IndexField("title", new IndexValue { Texts = ["Danish Title"] }, "da-DK", null),
+                ],
+            };
+            await IndexDocumentRepository.AddAsync(document);
+        }
+
+        // Verify the parent row exists
+        using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+        {
+            IndexDocument? doc = await IndexDocumentRepository.GetAsync(documentKey, false);
+            Assert.That(doc, Is.Not.Null, "Document should exist after adding");
+
+            Sql<ISqlContext> sql = scope.Database.SqlContext.Sql()
+                .Select<IndexDocumentDto>()
+                .From<IndexDocumentDto>()
+                .Where<IndexDocumentDto>(x => x.Key == documentKey);
+            List<IndexDocumentDto> parentRows = await scope.Database.FetchAsync<IndexDocumentDto>(sql);
+            Assert.That(parentRows, Has.Count.EqualTo(1), "Parent row should exist");
+        }
+
+        // Remove the only culture, which should also clean up the orphan parent
+        using (ScopeProvider.CreateScope(autoComplete: true))
+        {
+            await IndexDocumentRepository.RemoveFieldsByCultureAsync(["da-DK"]);
+        }
+
+        // Verify the parent row is gone (not just that GetAsync returns null)
+        using (IScope scope = ScopeProvider.CreateScope(autoComplete: true))
+        {
+            Sql<ISqlContext> sql = scope.Database.SqlContext.Sql()
+                .Select<IndexDocumentDto>()
+                .From<IndexDocumentDto>()
+                .Where<IndexDocumentDto>(x => x.Key == documentKey);
+            List<IndexDocumentDto> parentRows = await scope.Database.FetchAsync<IndexDocumentDto>(sql);
+            Assert.That(parentRows, Has.Count.EqualTo(0), "Orphan parent row should be cleaned up");
         }
     }
 
@@ -106,8 +163,8 @@ public class RemoveFieldsByCultureTests : TestBase
             .WithCultureInfo("ja-JP")
             .Build();
 
-        await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);
-        await LanguageService.CreateAsync(langJp, Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langDk, Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langJp, Constants.Security.SuperUserKey);
 
         IContentType contentType = new ContentTypeBuilder()
             .WithAlias("variantType")
@@ -115,8 +172,8 @@ public class RemoveFieldsByCultureTests : TestBase
             .AddPropertyType()
                 .WithAlias("title")
                 .WithVariations(ContentVariation.Culture)
-                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
-                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .WithDataTypeId(Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
                 .Done()
             .Build();
         ContentTypeService.Save(contentType);
@@ -161,9 +218,9 @@ public class RemoveFieldsByCultureTests : TestBase
             .WithCultureInfo("fr-FR")
             .Build();
 
-        await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);
-        await LanguageService.CreateAsync(langJp, Cms.Core.Constants.Security.SuperUserKey);
-        await LanguageService.CreateAsync(langFr, Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langDk, Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langJp, Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langFr, Constants.Security.SuperUserKey);
 
         IContentType contentType = new ContentTypeBuilder()
             .WithAlias("variantType")
@@ -171,8 +228,8 @@ public class RemoveFieldsByCultureTests : TestBase
             .AddPropertyType()
                 .WithAlias("title")
                 .WithVariations(ContentVariation.Culture)
-                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
-                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .WithDataTypeId(Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
                 .Done()
             .Build();
         ContentTypeService.Save(contentType);
@@ -213,7 +270,7 @@ public class RemoveFieldsByCultureTests : TestBase
             .WithCultureInfo("da-DK")
             .Build();
 
-        await LanguageService.CreateAsync(langDk, Cms.Core.Constants.Security.SuperUserKey);
+        await LanguageService.CreateAsync(langDk, Constants.Security.SuperUserKey);
 
         // Variant content type
         IContentType variantType = new ContentTypeBuilder()
@@ -222,8 +279,8 @@ public class RemoveFieldsByCultureTests : TestBase
             .AddPropertyType()
                 .WithAlias("title")
                 .WithVariations(ContentVariation.Culture)
-                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
-                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .WithDataTypeId(Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
                 .Done()
             .Build();
         ContentTypeService.Save(variantType);
@@ -235,8 +292,8 @@ public class RemoveFieldsByCultureTests : TestBase
             .AddPropertyType()
                 .WithAlias("title")
                 .WithVariations(ContentVariation.Nothing)
-                .WithDataTypeId(Cms.Core.Constants.DataTypes.Textbox)
-                .WithPropertyEditorAlias(Cms.Core.Constants.PropertyEditors.Aliases.TextBox)
+                .WithDataTypeId(Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
                 .Done()
             .Build();
         ContentTypeService.Save(invariantType);

--- a/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
@@ -73,6 +73,6 @@ public abstract class TestBase : UmbracoIntegrationTest
 
         public Task DeleteAllAsync() => Task.CompletedTask;
 
-        public Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes) => Task.CompletedTask;
+        public Task DeleteCulturesAsync(IReadOnlyCollection<string> isoCodes) => Task.CompletedTask;
     }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
@@ -72,5 +72,7 @@ public abstract class TestBase : UmbracoIntegrationTest
         public Task DeleteAsync(Guid[] ids, bool published) => Task.CompletedTask;
 
         public Task DeleteAllAsync() => Task.CompletedTask;
+
+        public Task RemoveFieldsByCultureAsync(IReadOnlyCollection<string> isoCodes) => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
# Notes
- Adds `RemoveFieldsByCultureAsync` to IndexDocumentService
- You can provide this method with a list of codes, which in turn get deleted
-  Splits the IndexDocument fields property into a new table, so we can delete all fields with a single query, and we don't have to filter everything in memore