### PR TITLE
Add provider name to index metadata and provider-aware UI conditioning

### DIFF
--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/bundle.manifests.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/bundle.manifests.ts
@@ -1,6 +1,7 @@
 import { manifests as localizationManifests } from './lang/manifests.js';
 import { manifests as collectionActionManifests } from './collectionActions.manifests.js';
 import { manifests as collectionViewManifests } from './collectionViews.manifests.js';
+import { manifests as conditionManifests } from './condition.manifests.js';
 import { manifests as entityActionManifests } from './entityActions.manifests.js';
 import { manifests as globalContextManifests } from './globalContexts.manifests.js';
 import { manifests as repositoryManifests } from './repositories.manifests.js';
@@ -20,6 +21,7 @@ export const manifests: Array<UmbExtensionManifest> = [
   ...repositoryManifests,
   ...collectionActionManifests,
   ...collectionViewManifests,
+  ...conditionManifests,
   ...entityActionManifests,
   ...searchRootWorkspaceManifests,
   ...searchWorkspaceManifests,

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/condition.manifests.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/condition.manifests.ts
@@ -1,0 +1,11 @@
+export const manifests: Array<UmbExtensionManifest> = [
+  {
+    type: 'condition',
+    name: 'Search Index Provider Name Condition',
+    alias: 'Umb.Search.Condition.IndexProviderName',
+    api: () =>
+      import('@umbraco-cms/search/settings').then((m) => ({
+        default: m.UmbSearchIndexProviderNameCondition,
+      })),
+  },
+];

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/lang/da.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/lang/da.ts
@@ -45,6 +45,7 @@ export default {
     rebuildIndex: 'Genopbyg indeks',
     indexInfo: 'Indeks information',
     indexAlias: 'Indeks alias',
+    providerName: 'Udbyderens navn',
     searchBox: 'Søg',
     searchPlaceholder: 'Søg i indeks...',
     searchButton: 'Søg',

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/lang/en.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/bundle/lang/en.ts
@@ -32,6 +32,7 @@ export default {
     rebuildIndex: 'Rebuild Index',
     indexInfo: 'Index Information',
     indexAlias: 'Index Alias',
+    providerName: 'Provider Name',
     searchBox: 'Search',
     searchPlaceholder: 'Search index...',
     searchButton: 'Search',

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/api/types.gen.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/api/types.gen.ts
@@ -40,6 +40,7 @@ export type HealthStatusModel = 'Healthy' | 'Rebuilding' | 'Corrupted' | 'Empty'
 
 export type IndexModel = {
     indexAlias: string;
+    providerName: string;
     documentCount: number;
     healthStatus: HealthStatusModel;
 };

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/index.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/index.ts
@@ -1,0 +1,1 @@
+export * from './indexProviderName.condition.js';

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/indexProviderName.condition.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/indexProviderName.condition.ts
@@ -1,0 +1,44 @@
+import {
+  ManifestCondition,
+  UmbConditionControllerArguments,
+  UmbExtensionCondition,
+} from '@umbraco-cms/backoffice/extension-api';
+import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
+import {
+  UMB_SEARCH_WORKSPACE_CONTEXT,
+  UmbSearchIndexProviderNameConditionConfig,
+} from '@umbraco-cms/search/settings';
+import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
+
+export class UmbSearchIndexProviderNameCondition
+  extends UmbConditionBase<UmbSearchIndexProviderNameConditionConfig>
+  implements UmbExtensionCondition
+{
+  constructor(
+    host: UmbControllerHost,
+    args: UmbConditionControllerArguments<UmbSearchIndexProviderNameConditionConfig>,
+  ) {
+    super(host, args);
+
+    const matchArray = args.config.oneOf ?? (args.config.match ? [args.config.match] : undefined) ?? [];
+
+    this.consumeContext(UMB_SEARCH_WORKSPACE_CONTEXT, (context) => {
+      if (!context) return;
+      this.observe(
+        context.providerName,
+        (providerName) => {
+          this.permitted = providerName ? stringOrStringArrayContains(matchArray, providerName) : false;
+        },
+        '_observeProviderName',
+      );
+    });
+  }
+}
+
+export const manifest: ManifestCondition = {
+  type: 'condition',
+  name: 'Search Index Provider Name Condition',
+  alias: 'Umb.Search.Condition.IndexProviderName',
+  api: UmbSearchIndexProviderNameCondition,
+};

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/indexProviderName.condition.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/indexProviderName.condition.ts
@@ -21,14 +21,16 @@ export class UmbSearchIndexProviderNameCondition
   ) {
     super(host, args);
 
-    const matchArray = args.config.oneOf ?? (args.config.match ? [args.config.match] : undefined) ?? [];
+    const matchArray =
+      args.config.oneOf ?? (args.config.match ? [args.config.match] : undefined) ?? [];
 
     this.consumeContext(UMB_SEARCH_WORKSPACE_CONTEXT, (context) => {
-      if (!context) return;
       this.observe(
-        context.providerName,
+        context?.providerName,
         (providerName) => {
-          this.permitted = providerName ? stringOrStringArrayContains(matchArray, providerName) : false;
+          this.permitted = providerName
+            ? stringOrStringArrayContains(matchArray, providerName)
+            : false;
         },
         '_observeProviderName',
       );

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/types.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/conditions/types.ts
@@ -1,0 +1,22 @@
+import type { UmbConditionConfigBase } from '@umbraco-cms/backoffice/extension-api';
+
+export interface UmbSearchIndexProviderNameConditionConfig extends UmbConditionConfigBase {
+  /**
+   * Define the provider name that this extension should be available for
+   * @example
+   * "Examine"
+   */
+  match?: string;
+  /**
+   * Define one or more provider names that this extension should be available for
+   * @example
+   * ["Examine"]
+   */
+  oneOf?: Array<string>;
+}
+
+declare global {
+  interface UmbExtensionConditionConfigMap {
+    umbSearchIndexProviderName: UmbSearchIndexProviderNameConditionConfig;
+  }
+}

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/index.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/index.ts
@@ -1,5 +1,6 @@
 // Library exports
 export * from './collection/index.js';
+export * from './conditions/index.js';
 export * from './repositories/index.js';
 export * from './workspace/index.js';
 export type * from './types.js';

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/repositories/search-collection.server.data-source.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/repositories/search-collection.server.data-source.ts
@@ -40,6 +40,7 @@ export class UmbSearchCollectionServerDataSource implements UmbSearchCollectionD
       return {
         unique: item.indexAlias,
         name: item.indexAlias,
+        providerName: item.providerName,
         documentCount: item.documentCount,
         healthStatus: item.healthStatus,
         entityType: UMB_SEARCH_INDEX_ENTITY_TYPE,

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/repositories/search-detail.server.data-source.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/repositories/search-detail.server.data-source.ts
@@ -30,6 +30,7 @@ export class UmbSearchServerDataSource implements UmbDetailDataSource<UmbSearchI
     const data: UmbSearchIndex = {
       entityType: UMB_SEARCH_INDEX_ENTITY_TYPE,
       name: preset.indexAlias!,
+      providerName: preset.providerName!,
       unique: preset.indexAlias!,
       documentCount: 0,
       state,

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/types.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/types.ts
@@ -1,11 +1,14 @@
 import { UmbCollectionDataSource } from '@umbraco-cms/backoffice/collection';
 
+export type * from './conditions/types.js';
+
 export type UmbSearchCollectionDataSource = UmbCollectionDataSource<UmbSearchIndex, never>;
 
 export type UmbSearchIndexState = 'idle' | 'loading' | 'error';
 export type UmbHealthStatusModel = 'Healthy' | 'Rebuilding' | 'Corrupted' | 'Empty' | 'Unknown';
 
 export type UmbSearchIndex = {
+  providerName: string;
   unique: string;
   name: string;
   documentCount: number;

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/workspace/search/search-workspace.context.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/workspace/search/search-workspace.context.ts
@@ -27,6 +27,7 @@ export class UmbSearchWorkspaceContext
     (x) => x?.documentCount,
   );
   public readonly healthStatus = this._data.createObservablePartOfPersisted((x) => x?.healthStatus);
+  public readonly providerName = this._data.createObservablePartOfPersisted((x) => x?.providerName);
   public readonly state = this._data.createObservablePartOfCurrent((x) => x?.state);
 
   #selectedCulture = new UmbStringState(undefined);

--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/workspace/search/views/search-index-stats-box.element.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/workspace/search/views/search-index-stats-box.element.ts
@@ -12,6 +12,9 @@ export class UmbSearchIndexStatsBoxElement extends UmbLitElement {
   private _indexAlias?: string;
 
   @state()
+  private _providerName?: string;
+
+  @state()
   private _documentCount?: number;
 
   @state()
@@ -33,6 +36,14 @@ export class UmbSearchIndexStatsBoxElement extends UmbLitElement {
         this._indexAlias = name;
       },
       '_observeName',
+    );
+
+    this.observe(
+      this.#workspaceContext?.providerName,
+      (name) => {
+        this._providerName = name;
+      },
+      '_observeProviderName',
     );
 
     this.observe(
@@ -73,6 +84,11 @@ export class UmbSearchIndexStatsBoxElement extends UmbLitElement {
           <div class="stat-item">
             <strong><umb-localize key="search_indexAlias">Index Alias</umb-localize></strong>
             <span>${this._indexAlias ?? '—'}</span>
+          </div>
+
+          <div class="stat-item">
+            <strong><umb-localize key="search_providerName">Provider Name</umb-localize></strong>
+            <span>${this._providerName ?? '—'}</span>
           </div>
 
           <div class="stat-item">

--- a/src/Umbraco.Cms.Search.Core/Controllers/GetAllIndexesApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/GetAllIndexesApiController.cs
@@ -43,6 +43,7 @@ public class GetAllIndexesApiController : ApiControllerBase
                 new IndexViewModel
                 {
                     IndexAlias = indexRegistration.IndexAlias,
+                    ProviderName = indexMetadata.ProviderName,
                     DocumentCount = indexMetadata.DocumentCount,
                     HealthStatus = indexMetadata.HealthStatus,
                 });

--- a/src/Umbraco.Cms.Search.Core/Controllers/GetIndexApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/GetIndexApiController.cs
@@ -37,6 +37,7 @@ public class GetIndexApiController : ApiControllerBase
         return Ok(new IndexViewModel
         {
             IndexAlias = indexAlias,
+            ProviderName = indexMetadata.ProviderName,
             DocumentCount = indexMetadata.DocumentCount,
             HealthStatus = indexMetadata.HealthStatus,
         });

--- a/src/Umbraco.Cms.Search.Core/Models/Indexing/IndexMetadata.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Indexing/IndexMetadata.cs
@@ -1,3 +1,3 @@
 ﻿namespace Umbraco.Cms.Search.Core.Models.Indexing;
 
-public record IndexMetadata(long DocumentCount, HealthStatus HealthStatus);
+public record IndexMetadata(long DocumentCount, HealthStatus HealthStatus, string ProviderName);

--- a/src/Umbraco.Cms.Search.Core/Models/ViewModels/IndexViewModel.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/ViewModels/IndexViewModel.cs
@@ -6,6 +6,8 @@ public class IndexViewModel
 {
     public required string IndexAlias { get; set; }
 
+    public required string ProviderName { get; set; }
+
     public long DocumentCount { get; set; }
 
     public HealthStatus HealthStatus { get; set; }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/src/examine-bundle.manifests.ts
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/src/examine-bundle.manifests.ts
@@ -22,6 +22,12 @@ export const manifests: Array<UmbExtensionManifest> = [
       label: '#searchExamine_showFields',
       additionalOptions: false,
     },
+    conditions: [
+      {
+        alias: 'Umb.Search.Condition.IndexProviderName',
+        match: 'Examine',
+      },
+    ],
   },
   {
     type: 'modal',

--- a/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
@@ -7,6 +7,11 @@ internal static class Constants
         public const string Name = "Examine";
     }
 
+    public static class Provider
+    {
+        public const string Name = Api.Name;
+    }
+
     public static class Variance
     {
         public const string Invariant = "none";

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Indexer.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Indexer.cs
@@ -173,13 +173,13 @@ public class Indexer : IExamineIndexer
                 activeDocCount = activeStats.GetDocumentCount();
             }
 
-            return Task.FromResult(new IndexMetadata(activeDocCount, HealthStatus.Rebuilding, Constants.Api.Name));
+            return Task.FromResult(new IndexMetadata(activeDocCount, HealthStatus.Rebuilding, Constants.Provider.Name));
         }
 
         var physicalName = _activeIndexManager.ResolveActiveIndexName(indexAlias);
         if (_examineManager.TryGetIndex(physicalName, out IIndex? index) is false)
         {
-            return Task.FromResult(new IndexMetadata(0, HealthStatus.Unknown, Constants.Api.Name));
+            return Task.FromResult(new IndexMetadata(0, HealthStatus.Unknown, Constants.Provider.Name));
         }
 
         var documentCount = 0L;
@@ -189,7 +189,7 @@ public class Indexer : IExamineIndexer
             documentCount = stats.GetDocumentCount();
             if (documentCount == 0L)
             {
-                return Task.FromResult(new IndexMetadata(0, HealthStatus.Empty, Constants.Api.Name));
+                return Task.FromResult(new IndexMetadata(0, HealthStatus.Empty, Constants.Provider.Name));
             }
         }
 
@@ -197,11 +197,11 @@ public class Indexer : IExamineIndexer
         try
         {
             index.Searcher.CreateQuery().ManagedQuery("__healthcheck__").Execute(new QueryOptions(0, 1));
-            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Healthy, Constants.Api.Name));
+            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Healthy, Constants.Provider.Name));
         }
         catch
         {
-            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Corrupted, Constants.Api.Name));
+            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Corrupted, Constants.Provider.Name));
         }
     }
 

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Indexer.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Indexer.cs
@@ -173,13 +173,13 @@ public class Indexer : IExamineIndexer
                 activeDocCount = activeStats.GetDocumentCount();
             }
 
-            return Task.FromResult(new IndexMetadata(activeDocCount, HealthStatus.Rebuilding));
+            return Task.FromResult(new IndexMetadata(activeDocCount, HealthStatus.Rebuilding, Constants.Api.Name));
         }
 
         var physicalName = _activeIndexManager.ResolveActiveIndexName(indexAlias);
         if (_examineManager.TryGetIndex(physicalName, out IIndex? index) is false)
         {
-            return Task.FromResult(new IndexMetadata(0, HealthStatus.Unknown));
+            return Task.FromResult(new IndexMetadata(0, HealthStatus.Unknown, Constants.Api.Name));
         }
 
         var documentCount = 0L;
@@ -189,7 +189,7 @@ public class Indexer : IExamineIndexer
             documentCount = stats.GetDocumentCount();
             if (documentCount == 0L)
             {
-                return Task.FromResult(new IndexMetadata(0, HealthStatus.Empty));
+                return Task.FromResult(new IndexMetadata(0, HealthStatus.Empty, Constants.Api.Name));
             }
         }
 
@@ -197,11 +197,11 @@ public class Indexer : IExamineIndexer
         try
         {
             index.Searcher.CreateQuery().ManagedQuery("__healthcheck__").Execute(new QueryOptions(0, 1));
-            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Healthy));
+            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Healthy, Constants.Api.Name));
         }
         catch
         {
-            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Corrupted));
+            return Task.FromResult(new IndexMetadata(documentCount, HealthStatus.Corrupted, Constants.Api.Name));
         }
     }
 

--- a/src/Umbraco.Test.Search.Integration/Services/TestIndexerAndSearcher.cs
+++ b/src/Umbraco.Test.Search.Integration/Services/TestIndexerAndSearcher.cs
@@ -46,7 +46,7 @@ public class TestIndexerAndSearcher : IIndexer, ISearcher
         return Task.CompletedTask;
     }
 
-    public Task<IndexMetadata> GetMetadataAsync(string indexAlias) => Task.FromResult(new IndexMetadata(GetIndex(indexAlias).Count, HealthStatus.Healthy));
+    public Task<IndexMetadata> GetMetadataAsync(string indexAlias) => Task.FromResult(new IndexMetadata(GetIndex(indexAlias).Count, HealthStatus.Healthy, "Test"));
 
     public IReadOnlyList<TestIndexDocument> Dump(string indexAlias) => GetIndex(indexAlias).Values.ToList();
 

--- a/src/Umbraco.Test.Search.Integration/Tests/ResolverTestsBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/ResolverTestsBase.cs
@@ -46,7 +46,7 @@ internal abstract class ResolverTestsBase<TResolver> : UmbracoIntegrationTest
             => throw new NotImplementedException();
 
         public Task<IndexMetadata> GetMetadataAsync(string indexAlias)
-            => Task.FromResult(new IndexMetadata(0, HealthStatus.Healthy));
+            => Task.FromResult(new IndexMetadata(0, HealthStatus.Healthy, "Test"));
     }
 
     protected abstract class SearcherBase : ISearcher


### PR DESCRIPTION
## Summary

- Adds `ProviderName` to `IndexMetadata` record and `IndexViewModel`, exposed through both index API endpoints
- Introduces `Umb.Search.Condition.IndexProviderName` — a new extension condition that lets provider-specific extensions conditionally render based on the active index's provider name
- The Examine "Show Fields" entity action now uses this condition so it only appears for Examine-backed indexes
- Displays provider name in the index detail stats box

## Questions for @kjac

- Is `ProviderName` the right property name on `IndexMetadata`, or should this be something else (e.g. `ProviderAlias`)?
- Should the provider name come from a constant/interface on `IIndexer` rather than being passed per-call in `GetMetadataAsync`?

## Test plan

- [ ] Verify "Show Fields" entity action only appears for Examine indexes
- [ ] Verify provider name displays correctly in index detail stats box
- [ ] Verify non-Examine providers (if any registered) do NOT show the "Show Fields" action
- [ ] Build passes: `dotnet build src/Umbraco.Cms.Search.sln`
- [ ] TypeScript checks pass for both Core and Examine clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)