### PR TITLE
Rename APIs

### DIFF
--- a/src/Umbraco.Cms.Search.Core.Client/Client/package.json
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "watch": "vite build --watch",
     "build": "tsc && vite build",
-    "generate-client": "node ../../scripts/generate-openapi.js https://localhost:44324/umbraco/swagger/Search/swagger.json src/settings/api",
+    "generate-client": "node ../../scripts/generate-openapi.js https://localhost:44324/umbraco/swagger/search/swagger.json src/settings/api",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "lint:errors-only": "eslint . --quiet",

--- a/src/Umbraco.Cms.Search.Core/Constants.cs
+++ b/src/Umbraco.Cms.Search.Core/Constants.cs
@@ -44,7 +44,7 @@ public static class Constants
 
     public static class Api
     {
-        public const string Name = "Search";
+        public const string Name = "search";
     }
 
     public static class Persistence

--- a/src/Umbraco.Cms.Search.Core/Controllers/ApiControllerBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/ApiControllerBase.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Search.Core.Controllers;
 [BackOfficeRoute("search/api/v{version:apiVersion}")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
 [MapToApi(Constants.Api.Name)]
-[ApiExplorerSettings(GroupName = "Search")]
+[ApiExplorerSettings(GroupName = "Umbraco Search")]
 public abstract class ApiControllerBase : ControllerBase
 {
 }

--- a/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -115,7 +115,7 @@ public static class UmbracoBuilderExtensions
             // Along with having a generated swagger JSON file that we can use to auto generate a TypeScript client
             opt.SwaggerDoc(Constants.Api.Name, new OpenApiInfo
             {
-                Title = "Search API",
+                Title = "Umbraco Search Management API",
                 Version = "1.0",
             });
 

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/package.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "watch": "vite build --watch",
     "build": "tsc && vite build",
-    "generate-client": "node ../../scripts/generate-openapi.js https://localhost:44324/umbraco/swagger/Examine/swagger.json src/api",
+    "generate-client": "node ../../scripts/generate-openapi.js https://localhost:44324/umbraco/swagger/examine/swagger.json src/api",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "lint:errors-only": "eslint . --quiet",

--- a/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
@@ -4,7 +4,7 @@ internal static class Constants
 {
     public static class Api
     {
-        public const string Name = "Examine";
+        public const string Name = "examine";
     }
 
     public static class Provider

--- a/src/Umbraco.Cms.Search.Provider.Examine/Controllers/ExamineApiController.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Controllers/ExamineApiController.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Search.Provider.Examine.Services;
 namespace Umbraco.Cms.Search.Provider.Examine.Controllers;
 
 [ApiVersion("1.0")]
-[ApiExplorerSettings(GroupName = Constants.Api.Name)]
+[ApiExplorerSettings(GroupName = "Umbraco Search (Examine Provider)")]
 public class ExamineApiController : ExamineApiControllerBase
 {
     private readonly IExamineManager _examineManager;

--- a/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -82,7 +82,7 @@ public static class UmbracoBuilderExtensions
         {
             opt.SwaggerDoc(Constants.Api.Name, new OpenApiInfo
             {
-                Title = "Examine API",
+                Title = "Umbraco Search Examine API",
                 Version = "1.0",
             });
 


### PR DESCRIPTION
Renamed the APIs to be a little more Umbraco flavored.

Note: This is only a UI enhancement. The API path stays the same (well, the casing changed).

### Before

### API selector

<img width="1362" height="299" alt="image" src="https://github.com/user-attachments/assets/0a16a86c-f28e-4744-a45e-0bbbb3223523" />

### Search core API

<img width="1362" height="595" alt="image" src="https://github.com/user-attachments/assets/b833683d-e18d-4d17-bcf5-d46f3a6b53ec" />

### Examine search provider API

<img width="1362" height="595" alt="image" src="https://github.com/user-attachments/assets/bd92a0e5-8709-4fd1-80c8-2ba86b7f7bb1" />

### After

### API selector

<img width="1362" height="287" alt="image" src="https://github.com/user-attachments/assets/110e91b3-9397-421c-8805-2e664922cd9d" />

### Search core API

<img width="1362" height="595" alt="image" src="https://github.com/user-attachments/assets/a7ec558f-88b9-45aa-9222-0aea96b8d92e" />

### Examine search provider API

<img width="1362" height="595" alt="image" src="https://github.com/user-attachments/assets/4332b73b-fb77-4561-ba2b-221540d30c9c" />
