### PR TITLE
Fix member enumeration (Closes #118)

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentChangeStrategyBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentChangeStrategyBase.cs
@@ -16,7 +16,7 @@ internal abstract class ContentChangeStrategyBase
 
     protected abstract bool SupportsTrashedContent { get; }
 
-    protected const int ContentEnumerationPageSize = 1000;
+    internal const int ContentEnumerationPageSize = 1000;
 
     protected ContentChangeStrategyBase(
         IUmbracoDatabaseFactory umbracoDatabaseFactory,

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DraftContentChangeStrategy.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/DraftContentChangeStrategy.cs
@@ -123,7 +123,7 @@ internal sealed class DraftContentChangeStrategy : ContentChangeStrategyBase, ID
                 break;
             }
 
-            members = _memberService.GetAll(pageIndex, ContentEnumerationPageSize, out _, "sortOrder", Direction.Ascending).ToArray();
+            members = _memberService.GetAll(pageIndex, ContentEnumerationPageSize, out _).ToArray();
             foreach (IMember member in members)
             {
                 if (cancellationToken.IsCancellationRequested)

--- a/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/PublishedContentChangeStrategy.cs
+++ b/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/PublishedContentChangeStrategy.cs
@@ -137,7 +137,7 @@ internal sealed class PublishedContentChangeStrategy : ContentChangeStrategyBase
                     return;
                 }
 
-                IMember[] members = _memberService.GetAll(pageIndex * ContentEnumerationPageSize, ContentEnumerationPageSize, out totalRecords, "sortOrder", Direction.Ascending).ToArray();
+                IMember[] members = _memberService.GetAll(pageIndex, ContentEnumerationPageSize, out totalRecords).ToArray();
                 foreach (IMember member in members)
                 {
                     if (cancellationToken.IsCancellationRequested)

--- a/src/Umbraco.Test.Search.Integration/Tests/MemberTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/MemberTests.cs
@@ -117,18 +117,18 @@ public class MemberTests : ContentBaseTestBase
 
         Assert.Multiple(() =>
         {
-            Assert.That(documents[0].Id, Is.EqualTo(MemberOneKey));
-            Assert.That(documents[1].Id, Is.EqualTo(MemberTwoKey));
-            Assert.That(documents[2].Id, Is.EqualTo(MemberThreeKey));
+            Assert.That(
+                documents.Select(d => d.Id),
+                Is.EquivalentTo(new[] { MemberOneKey, MemberTwoKey, MemberThreeKey }));
 
             Assert.That(documents.All(d => d.ObjectType is UmbracoObjectTypes.Member), Is.True);
         });
 
         Assert.Multiple(() =>
         {
-            VerifyDocumentPropertyValues(documents[0], "Organization One");
-            VerifyDocumentPropertyValues(documents[1], "Organization Two");
-            VerifyDocumentPropertyValues(documents[2], "Organization Three");
+            VerifyDocumentPropertyValues(documents.Single(d => d.Id == MemberOneKey), "Organization One");
+            VerifyDocumentPropertyValues(documents.Single(d => d.Id == MemberTwoKey), "Organization Two");
+            VerifyDocumentPropertyValues(documents.Single(d => d.Id == MemberThreeKey), "Organization Three");
         });
     }
 
@@ -144,6 +144,30 @@ public class MemberTests : ContentBaseTestBase
 
         documents = IndexerAndSearcher.Dump(IndexAliases.Media);
         Assert.That(documents, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public void Can_Index_More_Than_Content_Enumeration_Page_Size()
+    {
+        IMemberType memberType = MemberTypeService.GetAll().First();
+        foreach (var count in Enumerable.Range(1, ContentChangeStrategyBase.ContentEnumerationPageSize))
+        {
+            MemberService.Save(
+                new MemberBuilder()
+                    .WithKey(Guid.NewGuid())
+                    .WithMemberType(memberType)
+                    .WithName($"Member {count:0000}")
+                    .WithEmail($"member{count:0000}@local")
+                    .WithLogin($"member{count:0000}@local", "Test123456")
+                    .Build());
+        }
+
+        IndexerAndSearcher.Reset();
+
+        ContentIndexingService.Rebuild(IndexAliases.Member, DefaultOrigin);
+
+        IReadOnlyList<TestIndexDocument> documents = IndexerAndSearcher.Dump(IndexAliases.Member);
+        Assert.That(documents, Has.Count.EqualTo(ContentChangeStrategyBase.ContentEnumerationPageSize + 3));
     }
 
     private IMemberService MemberService => GetRequiredService<IMemberService>();

--- a/src/Umbraco.Test.Search.Integration/Tests/PublishedMemberTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/PublishedMemberTests.cs
@@ -196,18 +196,18 @@ public class PublishedMemberTests : TestBase
 
         Assert.Multiple(() =>
         {
-            Assert.That(documents[0].Id, Is.EqualTo(MemberOneKey));
-            Assert.That(documents[1].Id, Is.EqualTo(MemberTwoKey));
-            Assert.That(documents[2].Id, Is.EqualTo(MemberThreeKey));
+            Assert.That(
+                documents.Select(d => d.Id),
+                Is.EquivalentTo(new[] { MemberOneKey, MemberTwoKey, MemberThreeKey }));
 
             Assert.That(documents.All(d => d.ObjectType is UmbracoObjectTypes.Member), Is.True);
         });
 
         Assert.Multiple(() =>
         {
-            VerifyDocumentPropertyValues(documents[0], "Organization One");
-            VerifyDocumentPropertyValues(documents[1], "Organization Two");
-            VerifyDocumentPropertyValues(documents[2], "Organization Three");
+            VerifyDocumentPropertyValues(documents.Single(d => d.Id == MemberOneKey), "Organization One");
+            VerifyDocumentPropertyValues(documents.Single(d => d.Id == MemberTwoKey), "Organization Two");
+            VerifyDocumentPropertyValues(documents.Single(d => d.Id == MemberThreeKey), "Organization Three");
         });
     }
 

--- a/src/Umbraco.Web.TestSite.V17/Umbraco.Web.TestSite.V17.csproj
+++ b/src/Umbraco.Web.TestSite.V17/Umbraco.Web.TestSite.V17.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms" Version="17.2.2"/>
+        <PackageReference Include="Umbraco.Cms" Version="17.3.3" />
         <PackageReference Include="uSync" Version="17.0.2"/>
     </ItemGroup>
 


### PR DESCRIPTION
Fetch members with the correct `IMemberService.GetAll()` overload, and use the same method for both content change strategies.

Also updates the test site to a version where #118 is reproducable.

### Testing this

It's rather cumbersome to create 1000+ members ... the easier way around testing this is to:

1. Change the [`ContentEnumerationPageSize`](https://github.com/umbraco/Umbraco.Cms.Search/blob/main/src/Umbraco.Cms.Search.Core/Services/ContentIndexing/ContentChangeStrategyBase.cs#L19) to something a lot less (like 5).
2. Create `ContentEnumerationPageSize + 1` members.
3. Trigger a rebuild of the members index from the backoffice UI.