### PR TITLE
Move the OpenAPI spec for the Examine provider (Closes #121)

### DIFF
--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/package.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "watch": "vite build --watch",
     "build": "tsc && vite build",
-    "generate-client": "node ../../scripts/generate-openapi.js https://localhost:44324/umbraco/swagger/examine/swagger.json src/api",
+    "generate-client": "node ../../scripts/generate-openapi.js https://localhost:44324/umbraco/swagger/search-examine-provider/swagger.json src/api",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "lint:errors-only": "eslint . --quiet",

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/src/examine-bundle.manifests.ts
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/src/examine-bundle.manifests.ts
@@ -25,7 +25,7 @@ export const manifests: Array<UmbExtensionManifest> = [
     conditions: [
       {
         alias: 'Umb.Search.Condition.IndexProviderName',
-        match: 'Examine',
+        match: 'search-examine-provider',
       },
     ],
   },

--- a/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Constants.cs
@@ -4,7 +4,7 @@ internal static class Constants
 {
     public static class Api
     {
-        public const string Name = "examine";
+        public const string Name = "search-examine-provider";
     }
 
     public static class Provider


### PR DESCRIPTION
This PR moves the OpenAPI spec for the Examine provider from `/swagger/examine/` to `/swagger/search-examine-provider/` (see #121).

### Testing this PR

First and foremost, the backoffice UI for Umbraco Search should still work 😆 

Remember to verify that the Examine provider specific "show all fields" extension for search results is still shown and still works:

<img width="1247" height="647" alt="image" src="https://github.com/user-attachments/assets/518209fc-1e6c-454f-a75b-bd339e586097" />
