### PR TITLE
Make it possible to bypass the access context when querying (Closes #124)

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Models/Searching/AccessContext.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Searching/AccessContext.cs
@@ -1,6 +1,11 @@
-﻿namespace Umbraco.Cms.Search.Core.Models.Searching;
+﻿using System.Text.Json.Serialization;
 
-public record AccessContext(Guid PrincipalId, Guid[]? GroupIds, bool Ignore = false)
+namespace Umbraco.Cms.Search.Core.Models.Searching;
+
+public record AccessContext(Guid PrincipalId, Guid[]? GroupIds)
 {
-    public static AccessContext Ignored() => new(Guid.Empty, null, true);
+    [JsonIgnore]
+    public bool Bypass { get; private init; }
+
+    public static AccessContext BypassProtection() => new(Guid.Empty, null) { Bypass = true };
 }

--- a/src/Umbraco.Cms.Search.Core/Models/Searching/AccessContext.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/Searching/AccessContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace Umbraco.Cms.Search.Core.Models.Searching;
 
-public record AccessContext(Guid PrincipalId, Guid[]? GroupIds)
+public record AccessContext(Guid PrincipalId, Guid[]? GroupIds, bool Ignore = false)
 {
+    public static AccessContext Ignored() => new(Guid.Empty, null, true);
 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -194,7 +194,7 @@ public class Searcher : IExamineSearcher
 
     private void AddProtection(IBooleanOperation searchQuery, AccessContext? accessContext)
     {
-        if (accessContext?.Ignore is true)
+        if (accessContext?.Bypass is true)
         {
             return;
         }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -194,7 +194,12 @@ public class Searcher : IExamineSearcher
 
     private void AddProtection(IBooleanOperation searchQuery, AccessContext? accessContext)
     {
-        if (accessContext is null)
+        if (accessContext?.Ignore is true)
+        {
+            return;
+        }
+
+        if (accessContext is null || accessContext.PrincipalId == Guid.Empty)
         {
             searchQuery.And().Field(Constants.SystemFields.Protection, Guid.Empty.AsKeyword());
         }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/InvariantContentProtectionTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/InvariantContentProtectionTests.cs
@@ -185,8 +185,7 @@ public class InvariantContentProtectionTests : SearcherTestBase
                 });
         });
 
-
-        SearchResult results = await Searcher.SearchAsync(Cms.Search.Core.Constants.IndexAliases.PublishedContent, "root title", null, null, null, null, null, AccessContext.Ignored(), 0, 100);
+        SearchResult results = await Searcher.SearchAsync(Cms.Search.Core.Constants.IndexAliases.PublishedContent, "root title", null, null, null, null, null, AccessContext.BypassProtection(), 0, 100);
 
         Assert.That(results.Total, Is.EqualTo(1));
     }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/InvariantContentProtectionTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/InvariantContentProtectionTests.cs
@@ -168,6 +168,29 @@ public class InvariantContentProtectionTests : SearcherTestBase
         Assert.That(results.Total, Is.EqualTo(publish ? 0 : 1));
     }
 
+    [Test]
+    public async Task CanBypassProtection()
+    {
+        await MemberGroupService.CreateAsync(new MemberGroup() {Name = "testGroup"});
+
+        await WaitForIndexing(Cms.Search.Core.Constants.IndexAliases.PublishedContent, async () =>
+        {
+            await PublicAccessService.CreateAsync(
+                new PublicAccessEntrySlim
+                {
+                    ErrorPageId = RootKey,
+                    LoginPageId = RootKey,
+                    ContentId = RootKey,
+                    MemberGroupNames = ["testGroup"],
+                });
+        });
+
+
+        SearchResult results = await Searcher.SearchAsync(Cms.Search.Core.Constants.IndexAliases.PublishedContent, "root title", null, null, null, null, null, AccessContext.Ignored(), 0, 100);
+
+        Assert.That(results.Total, Is.EqualTo(1));
+    }
+
     [SetUp]
     public async Task CreateInvariantDocument()
     {


### PR DESCRIPTION
As per #124 - there are cases where one would like to surface search results despite them not necessarily being available for the current visitor.

This introduces an option to tell the searcher to ignore the access context when querying. Note that it is still up to the individual search provider to support this; logically, we can't enforce it from core.