### PR TITLE
Security harden APIs (Closes #128)

### DIFF
--- a/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/api/types.gen.ts
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/src/settings/api/types.gen.ts
@@ -4,11 +4,6 @@ export type ClientOptions = {
     baseUrl: 'https://localhost:44324' | (string & {});
 };
 
-export type AccessContextModel = {
-    principalId: string;
-    groupIds?: Array<string> | null;
-};
-
 export type DirectionModel = 'Ascending' | 'Descending';
 
 export type DocumentModel = {
@@ -58,7 +53,6 @@ export type SearchRequestModel = {
     sorters?: Array<SorterModel> | null;
     culture?: string | null;
     segment?: string | null;
-    accessContext?: AccessContextModel | null;
 };
 
 export type SearchResultModel = {
@@ -86,6 +80,10 @@ export type IndexesErrors = {
      * The resource is protected and requires an authentication token
      */
     401: unknown;
+    /**
+     * The authenticated user does not have access to this resource
+     */
+    403: unknown;
 };
 
 export type IndexesResponses = {
@@ -115,6 +113,10 @@ export type IndexErrors = {
      * The resource is protected and requires an authentication token
      */
     401: unknown;
+    /**
+     * The authenticated user does not have access to this resource
+     */
+    403: unknown;
     /**
      * Not Found
      */
@@ -149,6 +151,10 @@ export type RebuildErrors = {
      */
     401: unknown;
     /**
+     * The authenticated user does not have access to this resource
+     */
+    403: unknown;
+    /**
      * Not Found
      */
     404: unknown;
@@ -180,6 +186,10 @@ export type SearchErrors = {
      * The resource is protected and requires an authentication token
      */
     401: unknown;
+    /**
+     * The authenticated user does not have access to this resource
+     */
+    403: unknown;
     /**
      * Not Found
      */

--- a/src/Umbraco.Cms.Search.Core/Controllers/ApiControllerBase.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/ApiControllerBase.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Attributes;
+using Umbraco.Cms.Api.Management.Controllers;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Cms.Web.Common.Routing;
 
@@ -11,6 +12,6 @@ namespace Umbraco.Cms.Search.Core.Controllers;
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
 [MapToApi(Constants.Api.Name)]
 [ApiExplorerSettings(GroupName = "Umbraco Search")]
-public abstract class ApiControllerBase : ControllerBase
+public abstract class ApiControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Search.Core/Controllers/SearchApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/SearchApiController.cs
@@ -3,9 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
-using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Search.Core.Models.Searching;
 using Umbraco.Cms.Search.Core.Models.ViewModels;
@@ -19,18 +17,15 @@ public class SearchApiController : ApiControllerBase
     private readonly ISearcherResolver _searcherResolver;
     private readonly IEntityService _entityService;
     private readonly IVariationContextAccessor _variationContextAccessor;
-    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     public SearchApiController(
         ISearcherResolver searcherResolver,
         IEntityService entityService,
-        IVariationContextAccessor variationContextAccessor,
-        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+        IVariationContextAccessor variationContextAccessor)
     {
         _searcherResolver = searcherResolver;
         _entityService = entityService;
         _variationContextAccessor = variationContextAccessor;
-        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
     [HttpPost("search")]
@@ -50,9 +45,6 @@ public class SearchApiController : ApiControllerBase
             return NotFound($"No searcher was found for the index alias '{request.IndexAlias}'.");
         }
 
-        IUser user = CurrentUser(_backOfficeSecurityAccessor);
-        var accessContext = new AccessContext(user.Key, user.Groups.Select(group => group.Key).ToArray());
-
         SearchResult result = await searcher.SearchAsync(
             request.IndexAlias,
             request.Query,
@@ -61,7 +53,7 @@ public class SearchApiController : ApiControllerBase
             request.Sorters,
             request.Culture,
             request.Segment,
-            accessContext,
+            AccessContext.BypassProtection(),
             skip,
             take);
 

--- a/src/Umbraco.Cms.Search.Core/Controllers/SearchApiController.cs
+++ b/src/Umbraco.Cms.Search.Core/Controllers/SearchApiController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Search.Core.Models.Searching;
 using Umbraco.Cms.Search.Core.Models.ViewModels;
@@ -17,15 +19,18 @@ public class SearchApiController : ApiControllerBase
     private readonly ISearcherResolver _searcherResolver;
     private readonly IEntityService _entityService;
     private readonly IVariationContextAccessor _variationContextAccessor;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     public SearchApiController(
         ISearcherResolver searcherResolver,
         IEntityService entityService,
-        IVariationContextAccessor variationContextAccessor)
+        IVariationContextAccessor variationContextAccessor,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _searcherResolver = searcherResolver;
         _entityService = entityService;
         _variationContextAccessor = variationContextAccessor;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
     [HttpPost("search")]
@@ -45,6 +50,9 @@ public class SearchApiController : ApiControllerBase
             return NotFound($"No searcher was found for the index alias '{request.IndexAlias}'.");
         }
 
+        IUser user = CurrentUser(_backOfficeSecurityAccessor);
+        var accessContext = new AccessContext(user.Key, user.Groups.Select(group => group.Key).ToArray());
+
         SearchResult result = await searcher.SearchAsync(
             request.IndexAlias,
             request.Query,
@@ -53,7 +61,7 @@ public class SearchApiController : ApiControllerBase
             request.Sorters,
             request.Culture,
             request.Segment,
-            request.AccessContext,
+            accessContext,
             skip,
             take);
 

--- a/src/Umbraco.Cms.Search.Core/Models/ViewModels/SearchRequestModel.cs
+++ b/src/Umbraco.Cms.Search.Core/Models/ViewModels/SearchRequestModel.cs
@@ -20,6 +20,4 @@ public class SearchRequestModel
     public string? Culture { get; set; }
 
     public string? Segment { get; set; }
-
-    public AccessContext? AccessContext { get; set; }
 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Controllers/ExamineApiControllerBase.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Controllers/ExamineApiControllerBase.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.Attributes;
+using Umbraco.Cms.Api.Management.Controllers;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Cms.Web.Common.Routing;
 
@@ -10,4 +11,4 @@ namespace Umbraco.Cms.Search.Provider.Examine.Controllers;
 [BackOfficeRoute("examine/api/v{version:apiVersion}")]
 [Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
 [MapToApi(Constants.Api.Name)]
-public abstract class ExamineApiControllerBase : ControllerBase;
+public abstract class ExamineApiControllerBase : ManagementApiControllerBase;


### PR DESCRIPTION
This fixes #128 by adding a bit of security hardening to the APIs.

The changes are two-fold:

1. Ensure that all API controllers are built on the `ManagementApiControllerBase` from Umbraco as per the [recommendations from the official docs](https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-backoffice-api).
2. Do not accept an `AccessContext` from the backoffice UI when searching.

Of these two, number one is the only one that has any practical effect at this point. 

While number two sounds very impactful, it is in fact pretty cosmetic right now. The default `IContentProtectionProvider` only ever handles public access configurations for published content, and it is only used by the `PublishedContentChangeStrategy` when indexing published content. As such, an `AccessContext` based on `User` credentials has no effect; only ones based on `Member` credentials will potentially cause additional content to surface in a search result, and only for the published content index.

That being said, all these things are principally replaceable, so of course the search API controller should come prepared 😄 

### Testing this PR

As per the notes above, the PR should have noticeable effect, nor is it really possible to trigger any by means of restricting user access to content.

Verify that:

1. The Search UI still works (can find books in the test site), and
2. The Examine extension API also works (can show fields per search result).