### PR TITLE
Client: add README, LICENSE and npm package metadata

### DIFF
--- a/src/Umbraco.Cms.Search.Core.Client/Client/LICENSE
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Umbraco HQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Umbraco.Cms.Search.Core.Client/Client/README.md
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/README.md
@@ -1,0 +1,84 @@
+# @umbraco-cms/search
+
+TypeScript type definitions and runtime constants for extending the [Umbraco Search](https://docs.umbraco.com/umbraco-search/) backoffice.
+
+This package ships **types only** — no runtime code is bundled. Runtime symbols (contexts, constants) are resolved in the Umbraco backoffice via the import map provided by the Umbraco Search Core Client. Install this package as a `devDependency` to get type safety and IntelliSense when authoring search extensions and providers.
+
+## Installation
+
+```bash
+npm install --save-dev @umbraco-cms/search
+```
+
+> **Prereleases** are published under the `next` dist-tag:
+> ```bash
+> npm install --save-dev @umbraco-cms/search@next
+> ```
+
+**Peer dependency:** `@umbraco-cms/backoffice >= 17.0.0`
+
+## Entry points
+
+The package exposes two subpath entry points:
+
+| Import path                     | Contents                                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `@umbraco-cms/search/global`    | Entity-type constants, workspace aliases, and shared manifest types.                      |
+| `@umbraco-cms/search/settings`  | Workspace context tokens (`UMB_SEARCH_WORKSPACE_CONTEXT`), repositories, and view types.  |
+
+## Usage
+
+### Entity actions for search documents
+
+```typescript
+import { UMB_SEARCH_DOCUMENT_ENTITY_TYPE } from '@umbraco-cms/search/global';
+
+export const manifests: Array<UmbExtensionManifest> = [
+  {
+    type: 'entityAction',
+    kind: 'default',
+    alias: 'My.EntityAction.SearchDocument',
+    name: 'My Search Document Action',
+    api: () => import('./my-action.js'),
+    forEntityTypes: [UMB_SEARCH_DOCUMENT_ENTITY_TYPE],
+    meta: { icon: 'icon-search', label: 'My Action' },
+  },
+];
+```
+
+### Consuming the workspace context
+
+```typescript
+import { UMB_SEARCH_WORKSPACE_CONTEXT } from '@umbraco-cms/search/settings';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+export class MyBoxElement extends UmbLitElement {
+  constructor() {
+    super();
+    this.consumeContext(UMB_SEARCH_WORKSPACE_CONTEXT, (context) => {
+      const indexAlias = context.getUnique();
+      this.observe(context.documentCount, (count) => {
+        // ...
+      });
+    });
+  }
+}
+```
+
+### Detail boxes, workspace views, routable modals
+
+The Search backoffice exposes additional extension points (`searchIndexDetailBox`, workspace views targeting `UMB_SEARCH_WORKSPACE_ALIAS`, and routable-modal patterns for deep-linkable document detail pages). See the full guide below.
+
+## Documentation
+
+The complete guide for extending the Search backoffice — including detail boxes, workspace views, routable modals, and cross-package type augmentation — lives in the Umbraco docs:
+
+**[Extending the Search Backoffice →](https://docs.umbraco.com/umbraco-search/extending/backoffice-extensions)**
+
+## Source
+
+This package is generated from the Core Client workspace in [umbraco/Umbraco.Cms.Search](https://github.com/umbraco/Umbraco.Cms.Search). Issues and contributions welcome.
+
+## License
+
+MIT

--- a/src/Umbraco.Cms.Search.Core.Client/Client/package.json
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/package.json
@@ -1,6 +1,17 @@
 {
   "name": "@umbraco-cms/search",
   "version": "0.0.0",
+  "description": "TypeScript type definitions for extending the Umbraco Search backoffice.",
+  "license": "MIT",
+  "homepage": "https://docs.umbraco.com/umbraco-search/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/umbraco/Umbraco.Cms.Search.git",
+    "directory": "src/Umbraco.Cms.Search.Core.Client/Client"
+  },
+  "bugs": {
+    "url": "https://github.com/umbraco/Umbraco.Cms.Search/issues"
+  },
   "type": "module",
   "exports": {
     "./global": {


### PR DESCRIPTION
## Summary
- The first published `@umbraco-cms/search@1.0.0-beta.6` tarball had no README, no LICENSE and no repository/description/license metadata, so the [npmjs.com listing](https://www.npmjs.com/package/@umbraco-cms/search) is blank.
- This PR adds a concise README covering installation, the two entry points (`/global`, `/settings`), a couple of usage examples and a link to the [Extending the Search Backoffice](https://docs.umbraco.com/umbraco-search/extending/backoffice-extensions) docs page (deeper guidance lives there, not duplicated here).
- Adds the repo-root MIT `LICENSE` into the package root so it ships inside the tarball.
- Adds `description`, `license`, `homepage`, `repository` (with `directory`) and `bugs` fields to `package.json` so npmjs.com renders properly and links back to this repo.

## Verification
`npm pack --dry-run` confirms README + LICENSE are picked up automatically (no `files` array change needed):
```
npm notice 1.1kB LICENSE
npm notice 3.1kB README.md
npm notice 1.3kB package.json
```

## Test plan
- [ ] Next prerelease publish to npmjs.com renders README and shows MIT badge
- [ ] Repository link on the npm page points back to this repo's Client subdirectory
- [ ] `npm view @umbraco-cms/search` shows `license`, `homepage`, `repository.directory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)