### PR TITLE
Downgrade Examine to 4.0.0-beta.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Examine" Version="4.0.0-beta.3" />
+    <PackageVersion Include="Examine" Version="4.0.0-beta.1" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/Umbraco.Cms.Search.Provider.Examine/Extensions/ExamineValueExtensions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Extensions/ExamineValueExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Examine.Search;
+
+namespace Umbraco.Cms.Search.Provider.Examine.Extensions;
+
+// TODO: remove this with the next version of Examine
+internal static class ExamineValueExtensions
+{
+    public static IExamineValue WithBoost(this IExamineValue value, float _) => value;
+}

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/QueryTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/QueryTests.cs
@@ -135,6 +135,8 @@ public class QueryTests : SearcherTestBase
     // itself carries the relevance-tier boost (R1 > R2 > R3 > Texts) — without the boost
     // on the wildcard, all four documents would tie at the same constant wildcard score.
     [Test]
+    // TODO: include this with the next version of Examine
+    [Ignore("Does not work with the current version of Examine")]
     public async Task WildcardOnlyMatchesRespectRelevanceTierBoost()
     {
         SearchResult result = await SearchAsync(


### PR DESCRIPTION
As mentioned in #137, Examine 4.0.0-beta.3 breaks Umbraco. This PR downgrades while retaining as much of [initial upgrade](https://github.com/umbraco/Umbraco.Cms.Search/pull/134) as possible.

When a new version of Examine lands, we need to revert the changes in this PR.