### PR TITLE
Versioning: Seperate Examine package from core packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,10 +25,6 @@
     <PackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>

--- a/src/Umbraco.Cms.Search.Provider.Examine/version.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.9",
+  "inherit": false,
   "assemblyVersion": {
     "precision": "build"
   },
@@ -18,6 +19,6 @@
     }
   },
   "release": {
-    "branchName": "release/{version}"
+    "branchName": "release/examine/{version}"
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.0.0-rc1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
# Notes
- Seperates the Examine.Provider version from the other packages, this means we can release the core packages as final versions, while keeping the examine package in beta, while awaiting the final version

# How to test
- Run a local `dotnet pack` assert that the versions are now seperate 😁 
- You can also check this with the `nbgv` tool in the terminal 🫡 