### PR TITLE
Use score sorting for backoffice search (closes #141)

### DIFF
--- a/src/Umbraco.Cms.Search.BackOffice/Services/ContentSearchServiceBase.cs
+++ b/src/Umbraco.Cms.Search.BackOffice/Services/ContentSearchServiceBase.cs
@@ -52,14 +52,14 @@ internal abstract class ContentSearchServiceBase<TContent> : IndexedSearchServic
             filters.Add(new IntegerExactFilter(Core.Constants.FieldNames.Level, [1], false));
         }
 
-        Sorter? sorter = GetSorter(ordering);
+        Sorter sorter = GetSorter(ordering);
 
         SearchResult result = await _searcher.SearchAsync(
             IndexAlias,
             query: effectiveQuery,
             filters: filters,
             facets: null,
-            sorters: sorter != null ? [sorter] : null,
+            sorters: [sorter],
             culture: ordering?.Culture,
             segment: null,
             accessContext: null,
@@ -118,17 +118,17 @@ internal abstract class ContentSearchServiceBase<TContent> : IndexedSearchServic
         };
     }
 
-    private Sorter? GetSorter(Ordering? ordering)
+    private Sorter GetSorter(Ordering? ordering)
     {
         if (ordering?.OrderBy is null)
         {
-            return null;
+            return DefaultSorter();
         }
 
         if (ordering.IsCustomField)
         {
             // TODO: support custom field ordering
-            return null;
+            return DefaultSorter();
         }
 
         switch (ordering.OrderBy)
@@ -142,10 +142,12 @@ internal abstract class ContentSearchServiceBase<TContent> : IndexedSearchServic
                 // NOTE: "creator" / "owner" is configurable for list view but not supported here,
                 //       because this will require a full re-index when any username is changed
                 _logger.LogInformation("The system field \"{field}\" does not support sorting by indexed content search.", ordering.OrderBy);
-                return null;
+                return DefaultSorter();
             default:
                 _logger.LogInformation("The system field \"{field}\" could not be converted into a sorting by indexed content search.", ordering.OrderBy);
-                return null;
+                return DefaultSorter();
         }
+
+        Sorter DefaultSorter() => new ScoreSorter(Direction.Descending);
     }
 }

--- a/src/Umbraco.Cms.Search.BackOffice/Services/ContentSearchServiceBase.cs
+++ b/src/Umbraco.Cms.Search.BackOffice/Services/ContentSearchServiceBase.cs
@@ -122,13 +122,13 @@ internal abstract class ContentSearchServiceBase<TContent> : IndexedSearchServic
     {
         if (ordering?.OrderBy is null)
         {
-            return DefaultSorter();
+            return Sorting.Default();
         }
 
         if (ordering.IsCustomField)
         {
             // TODO: support custom field ordering
-            return DefaultSorter();
+            return Sorting.Default();
         }
 
         switch (ordering.OrderBy)
@@ -142,12 +142,10 @@ internal abstract class ContentSearchServiceBase<TContent> : IndexedSearchServic
                 // NOTE: "creator" / "owner" is configurable for list view but not supported here,
                 //       because this will require a full re-index when any username is changed
                 _logger.LogInformation("The system field \"{field}\" does not support sorting by indexed content search.", ordering.OrderBy);
-                return DefaultSorter();
+                return Sorting.Default();
             default:
                 _logger.LogInformation("The system field \"{field}\" could not be converted into a sorting by indexed content search.", ordering.OrderBy);
-                return DefaultSorter();
+                return Sorting.Default();
         }
-
-        Sorter DefaultSorter() => new ScoreSorter(Direction.Descending);
     }
 }

--- a/src/Umbraco.Cms.Search.BackOffice/Services/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Cms.Search.BackOffice/Services/IndexedEntitySearchService.cs
@@ -106,7 +106,7 @@ internal sealed class IndexedEntitySearchService : IndexedSearchServiceBase, IIn
             query: effectiveQuery,
             filters: filters,
             facets: null,
-            sorters: [new ScoreSorter(Direction.Descending)],
+            sorters: [Sorting.Default()],
             culture: culture,
             segment: null,
             accessContext: null,

--- a/src/Umbraco.Cms.Search.BackOffice/Services/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Cms.Search.BackOffice/Services/IndexedEntitySearchService.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Search.Core.Extensions;
 using Umbraco.Cms.Search.Core.Models.Searching;
 using Umbraco.Cms.Search.Core.Models.Searching.Filtering;
+using Umbraco.Cms.Search.Core.Models.Searching.Sorting;
 using Umbraco.Cms.Search.Core.Services;
 using Constants = Umbraco.Cms.Search.Core.Constants;
 
@@ -105,7 +106,7 @@ internal sealed class IndexedEntitySearchService : IndexedSearchServiceBase, IIn
             query: effectiveQuery,
             filters: filters,
             facets: null,
-            sorters: null,
+            sorters: [new ScoreSorter(Direction.Descending)],
             culture: culture,
             segment: null,
             accessContext: null,
@@ -114,7 +115,12 @@ internal sealed class IndexedEntitySearchService : IndexedSearchServiceBase, IIn
 
         Guid[] resultKeys = result.Documents.Select(d => d.Id).ToArray();
         IEntitySlim[] resultEntities = resultKeys.Any()
-            ? _entityService.GetAll(objectType, resultKeys).ToArray()
+            ? _entityService
+                .GetAll(objectType, resultKeys)
+                // unfortunately we can't explicitly rely on the underlying services ordering the requested
+                // items correctly, so we need to enforce correct ordering here.
+                .OrderBy(entity => resultKeys.IndexOf(entity.Key))
+                .ToArray()
             : [];
 
         return new PagedModel<IEntitySlim> { Items = resultEntities, Total = result.Total };

--- a/src/Umbraco.Cms.Search.BackOffice/Services/Sorting.cs
+++ b/src/Umbraco.Cms.Search.BackOffice/Services/Sorting.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Search.Core.Models.Searching.Sorting;
+
+namespace Umbraco.Cms.Search.BackOffice.Services;
+
+internal static class Sorting
+{
+    public static Sorter Default() => new ScoreSorter(Direction.Descending);
+}

--- a/src/Umbraco.Test.Search.Integration/Services/TestIndexerAndSearcher.cs
+++ b/src/Umbraco.Test.Search.Integration/Services/TestIndexerAndSearcher.cs
@@ -141,6 +141,15 @@ public class TestIndexerAndSearcher : IIndexer, ISearcher
                     document.Fields.FirstOrDefault(field =>
                         IsVarianceMatch(field)
                         && field.FieldName == dateTimeOffsetSorter.FieldName)?.Value.DateTimeOffsets?.FirstOrDefault()).ToArray(),
+                ScoreSorter when query is not null => result.OrderBy(document =>
+                        document.Fields.Any(f => string.Join(" ", f.Value.TextsR1.EmptyNull()).InvariantContains(query))
+                            ? 4
+                            : document.Fields.Any(f => string.Join(" ", f.Value.TextsR2.EmptyNull()).InvariantContains(query))
+                                ? 3
+                                : document.Fields.Any(f => string.Join(" ", f.Value.TextsR3.EmptyNull()).InvariantContains(query))
+                                    ? 2
+                                    : 1)
+                    .ToArray(),
                 _ => result
             };
 

--- a/src/Umbraco.Test.Search.Integration/Tests/BackOffice/BackOfficeTestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BackOffice/BackOfficeTestBase.cs
@@ -74,7 +74,7 @@ public abstract class BackOfficeTestBase : TestBase
         {
             Content root = new ContentBuilder()
                 .WithContentType(rootContentType)
-                .WithName($"Root {i}")
+                .WithName($"Root {i} shared shared{i}")
                 .WithPropertyValues(
                     new
                     {
@@ -94,7 +94,7 @@ public abstract class BackOfficeTestBase : TestBase
                     .WithPropertyValues(
                         new
                         {
-                            title = $"child title single{j}child triple{j/3}child oddeven{j%2}child"
+                            title = $"child title single{j}child triple{j/3}child oddeven{j%2}child shared shared{i}"
                         })
                     .Build();
                 ContentService.Save(child);
@@ -135,7 +135,7 @@ public abstract class BackOfficeTestBase : TestBase
         {
             Media folder = new MediaBuilder()
                 .WithMediaType(rootMediaType)
-                .WithName($"Root {i}")
+                .WithName($"Root {i} shared shared{i}")
                 .WithPropertyValues(
                     new
                     {
@@ -154,7 +154,7 @@ public abstract class BackOfficeTestBase : TestBase
                     .WithPropertyValues(
                         new
                         {
-                            title = $"child title single{j}child triple{j/3}child oddeven{j%2}child"
+                            title = $"child title single{j}child triple{j/3}child oddeven{j%2}child shared shared{i}"
                         })
                     .WithParentId(folder.Id)
                     .Build();

--- a/src/Umbraco.Test.Search.Integration/Tests/BackOffice/ContentSearchServiceTests.Content.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BackOffice/ContentSearchServiceTests.Content.cs
@@ -82,9 +82,9 @@ public partial class ContentSearchServiceTests
         {
             Assert.That(result.Total, Is.EqualTo(3));
             IContent[] items = result.Items.OrderBy(item => item.SortOrder).ToArray();
-            Assert.That(items[0].Name, Is.EqualTo("Root 0"));
-            Assert.That(items[1].Name, Is.EqualTo("Root 1"));
-            Assert.That(items[2].Name, Is.EqualTo("Root 2"));
+            Assert.That(items[0].Name, Is.EqualTo("Root 0 shared shared0"));
+            Assert.That(items[1].Name, Is.EqualTo("Root 1 shared shared1"));
+            Assert.That(items[2].Name, Is.EqualTo("Root 2 shared shared2"));
         });
     }
 
@@ -96,7 +96,7 @@ public partial class ContentSearchServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.Total, Is.EqualTo(1));
-            Assert.That(result.Items.First().Name, Is.EqualTo("Root 1"));
+            Assert.That(result.Items.First().Name, Is.EqualTo("Root 1 shared shared1"));
         });
     }
 

--- a/src/Umbraco.Test.Search.Integration/Tests/BackOffice/ContentSearchServiceTests.Media.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BackOffice/ContentSearchServiceTests.Media.cs
@@ -82,9 +82,9 @@ public partial class ContentSearchServiceTests
         {
             Assert.That(result.Total, Is.EqualTo(3));
             IMedia[] items = result.Items.OrderBy(item => item.SortOrder).ToArray();
-            Assert.That(items[0].Name, Is.EqualTo("Root 0"));
-            Assert.That(items[1].Name, Is.EqualTo("Root 1"));
-            Assert.That(items[2].Name, Is.EqualTo("Root 2"));
+            Assert.That(items[0].Name, Is.EqualTo("Root 0 shared shared0"));
+            Assert.That(items[1].Name, Is.EqualTo("Root 1 shared shared1"));
+            Assert.That(items[2].Name, Is.EqualTo("Root 2 shared shared2"));
         });
     }
 
@@ -96,7 +96,7 @@ public partial class ContentSearchServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(result.Total, Is.EqualTo(1));
-            Assert.That(result.Items.First().Name, Is.EqualTo("Root 1"));
+            Assert.That(result.Items.First().Name, Is.EqualTo("Root 1 shared shared1"));
         });
     }
 

--- a/src/Umbraco.Test.Search.Integration/Tests/BackOffice/IndexedEntitySearchServiceTests.Content.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BackOffice/IndexedEntitySearchServiceTests.Content.cs
@@ -217,4 +217,34 @@ public partial class IndexedEntitySearchServiceTests
 
         Assert.That(result.Total, Is.EqualTo(expectedTotal));
     }
+
+    [Test]
+    public async Task Content_RespectsTextBoostingTiers_All()
+    {
+        PagedModel<IEntitySlim> result = await IndexedEntitySearchService.SearchAsync(
+            UmbracoObjectTypes.Document,
+            query: "shared",
+            parentId: null,
+            contentTypeIds: null,
+            trashed: false);
+
+        Assert.That(result.Total, Is.EqualTo(22));
+        Assert.That(result.Items.Take(2).All(c => c.Name!.Contains("Root")), Is.True);
+        Assert.That(result.Items.Skip(2).All(c => c.Name!.Contains("Child")), Is.True);
+    }
+
+    [Test]
+    public async Task Content_RespectsTextBoostingTiers_Single()
+    {
+        PagedModel<IEntitySlim> result = await IndexedEntitySearchService.SearchAsync(
+            UmbracoObjectTypes.Document,
+            query: "shared1",
+            parentId: null,
+            contentTypeIds: null,
+            trashed: false);
+
+        Assert.That(result.Total, Is.EqualTo(11));
+        Assert.That(result.Items.First().Name, Is.EqualTo("Root 1 shared shared1"));
+        Assert.That(result.Items.Skip(1).All(c => c.Name!.Contains("Child")), Is.True);
+    }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/BackOffice/IndexedEntitySearchServiceTests.Media.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/BackOffice/IndexedEntitySearchServiceTests.Media.cs
@@ -217,4 +217,34 @@ public partial class IndexedEntitySearchServiceTests
 
         Assert.That(expectedTotal, Is.EqualTo(result.Total));
     }
+
+    [Test]
+    public async Task Media_RespectsTextBoostingTiers_All()
+    {
+        PagedModel<IEntitySlim> result = await IndexedEntitySearchService.SearchAsync(
+            UmbracoObjectTypes.Media,
+            query: "shared",
+            parentId: null,
+            contentTypeIds: null,
+            trashed: false);
+
+        Assert.That(result.Total, Is.EqualTo(22));
+        Assert.That(result.Items.Take(2).All(c => c.Name!.Contains("Root")), Is.True);
+        Assert.That(result.Items.Skip(2).All(c => c.Name!.Contains("Child")), Is.True);
+    }
+
+    [Test]
+    public async Task Media_RespectsTextBoostingTiers_Single()
+    {
+        PagedModel<IEntitySlim> result = await IndexedEntitySearchService.SearchAsync(
+            UmbracoObjectTypes.Media,
+            query: "shared1",
+            parentId: null,
+            contentTypeIds: null,
+            trashed: false);
+
+        Assert.That(result.Total, Is.EqualTo(11));
+        Assert.That(result.Items.First().Name, Is.EqualTo("Root 1 shared shared1"));
+        Assert.That(result.Items.Skip(1).All(c => c.Name!.Contains("Child")), Is.True);
+    }
 }


### PR DESCRIPTION
As mentioned in #141, the backoffice search result order seems rather random.

In fact, it rather is 🙈 

This is in part because Umbraco does not enforce a sort order for the backoffice search (at least not the "global" search). It's not a huge problem in Umbraco _without_ Umbraco Search because the default search surfaces a lot less results. 

We can mitigate this in Umbraco Search by sorting by score if no explicit sort order has been requested. So that's what this PR does.

**Before**

<img width="763" height="1054" alt="image" src="https://github.com/user-attachments/assets/da0f9293-566a-40be-ad83-5d227cd364a5" />

**After**

<img width="763" height="1054" alt="image" src="https://github.com/user-attachments/assets/398eb1e9-859f-4306-97bf-5c5dac9ba44d" />

## Testing this PR

Verify that backoffice search results are in a logical order, in respect to the search query,
