### PR TITLE
Align package versions with CMS major (v1 → v17)

### DIFF
--- a/src/Umbraco.Cms.Search.Core.Client/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Search.Core.Client/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
   "id": "Umbraco.Cms.Search.Core",
   "name": "@umbraco-cms/search",
-  "version": "1.0.0",
+  "version": "17.0.0",
   "allowTelemetry": true,
   "extensions": [
     {

--- a/src/Umbraco.Cms.Search.Provider.Examine/Client/public/umbraco-package.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
   "id": "Umbraco.Cms.Search.Provider.Examine",
   "name": "@umbraco-cms/search/examine",
-  "version": "1.0.0",
+  "version": "17.0.0",
   "allowTelemetry": true,
   "extensions": [
     {

--- a/src/Umbraco.Cms.Search.Provider.Examine/version.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.0.0",
+  "version": "17.0.0-beta.1",
   "inherit": false,
   "assemblyVersion": {
     "precision": "build"

--- a/src/Umbraco.Cms.Search.Provider.Examine/version.json
+++ b/src/Umbraco.Cms.Search.Provider.Examine/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0-beta.9",
+  "version": "17.0.0",
   "inherit": false,
   "assemblyVersion": {
     "precision": "build"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "17.0.0",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
## Summary

Bumps our package versioning from `1.x` to `17.x` to align our major version with the Umbraco CMS major we target.

- `version.json`: `1.0.0` → `17.0.0`
- `src/Umbraco.Cms.Search.Provider.Examine/version.json`: `1.0.0-beta.9` → `17.0.0-beta.1` (Examine itself is still in beta, so keeping provider as prerelease)
- `umbraco-package.json` (Core Client): `1.0.0` → `17.0.0`
- `umbraco-package.json` (Examine Client): `1.0.0` → `17.0.0`

No NuGet or npm dependency changes — those were already at v17.

## Test plan

- [ ] Verify `dotnet build src/Umbraco.Cms.Search.sln` succeeds
- [ ] Verify NuGet package output versions are `17.0.0` / `17.0.0-beta.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)