### PR TITLE
Bump to beta 9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Examine" Version="4.0.0-beta.4" />
+    <PackageVersion Include="Examine" Version="4.0.0-beta.9" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/Umbraco.Cms.Search.Provider.Examine/Configuration/ConfigureIndexOptions.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Configuration/ConfigureIndexOptions.cs
@@ -28,6 +28,8 @@ internal sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirec
 
     private void AddOptions(LuceneDirectoryIndexOptions options)
     {
+        // None of the search indexes use the Taxonomy index, as we instead use the non-taxonomy types like (FacetInteger / FacetDouble) so disable it.
+        options.UseTaxonomyIndex = false;
         AddFields(options, ExamineSystemFieldsOptions(), (field, _) => field.PropertyName);
         AddFields(options, CoreSystemFieldsOptions(), (field, fieldValues) => FieldNameHelper.FieldName(field.PropertyName, fieldValues));
         AddFields(options, _fieldOptions.Fields, (field, fieldValues) => FieldNameHelper.FieldName(field.PropertyName, fieldValues));


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco.Cms.Search/issues/144

# Notes 
- Updates to the newly released `examine-beta.9`
- Also disables the taxonomy index, as we don't use it at all.

# How to test 
- In the appsettings.json of the TestSite, enable `SyncedTempFileSystemDirectory`
```
  "Umbraco": {
    "CMS": {
      "Examine": {
        "LuceneDirectoryFactory" : "SyncedTempFileSystemDirectoryFactory"
      },
```

- Run the site, it should no longer be throwing errors, and there should be physical indexes in `TEMP/ExamineIndexes`