### PR TITLE
V18: Fix tests

### DIFF
--- a/src/Umbraco.Cms.Search.Core/NotificationHandlers/RebuildIndexesNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/NotificationHandlers/RebuildIndexesNotificationHandler.cs
@@ -88,7 +88,7 @@ internal sealed class RebuildIndexesNotificationHandler : IndexingNotificationHa
     private void HandleContentTypeChanges(IEnumerable<(Guid ContentTypeKey, ContentTypeChangeTypes ChangeTypes)> changes, UmbracoObjectTypes objectType, string origin)
     {
         Guid[] affectedContentTypeKeys = changes
-            .Where(change => change.ChangeTypes is ContentTypeChangeTypes.RefreshMain or ContentTypeChangeTypes.Remove)
+            .Where(change => change.ChangeTypes.HasFlag(ContentTypeChangeTypes.RefreshMain) || change.ChangeTypes.HasFlag(ContentTypeChangeTypes.Remove))
             .Select(change => change.ContentTypeKey)
             .Distinct()
             .ToArray();

--- a/src/Umbraco.Cms.Search.Core/Persistence/Migration/CustomPackageMigration.cs
+++ b/src/Umbraco.Cms.Search.Core/Persistence/Migration/CustomPackageMigration.cs
@@ -29,9 +29,8 @@ public class CustomPackageMigration : AsyncPackageMigrationBase
             shortStringHelper,
             contentTypeBaseServiceProvider,
             context,
-            packageMigrationsSettings)
-    {
-    }
+            packageMigrationsSettings) =>
+        RebuildCache = false;
 
     protected override Task MigrateAsync()
     {

--- a/src/Umbraco.Cms.Search.Provider.Examine/NotificationHandlers/RebuildNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/NotificationHandlers/RebuildNotificationHandler.cs
@@ -44,10 +44,8 @@ public class RebuildNotificationHandler : INotificationHandler<UmbracoApplicatio
 
             if (_examineManager.TryGetIndex(activePhysicalName, out IIndex? index))
             {
-                // Check if active physical index exists and has content, if it does, we can skip rebuilding.
-                // IndexExists() alone is not enough: Examine commits an empty index as soon as it opens it,
-                // so a never-populated index still reports as "existing".
-                if (index.IndexExists() && index is IIndexStats stats && stats.GetDocumentCount() > 0)
+                // Check if active physical index exists, if it does, we can skip rebuilding
+                if (index.IndexExists())
                 {
                     continue;
                 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/NotificationHandlers/RebuildNotificationHandler.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/NotificationHandlers/RebuildNotificationHandler.cs
@@ -44,8 +44,10 @@ public class RebuildNotificationHandler : INotificationHandler<UmbracoApplicatio
 
             if (_examineManager.TryGetIndex(activePhysicalName, out IIndex? index))
             {
-                // Check if active physical index exists, if it does, we can skip rebuilding
-                if (index.IndexExists())
+                // Check if active physical index exists and has content, if it does, we can skip rebuilding.
+                // IndexExists() alone is not enough: Examine commits an empty index as soon as it opens it,
+                // so a never-populated index still reports as "existing".
+                if (index.IndexExists() && index is IIndexStats stats && stats.GetDocumentCount() > 0)
                 {
                     continue;
                 }

--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/IndexCommitMonitor.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/IndexCommitMonitor.cs
@@ -47,7 +47,7 @@ internal sealed class IndexCommitMonitor : IIndexCommitMonitor
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
             while (!committed && stopwatch.Elapsed < _commitTimeout)
             {
-                await Task.Delay(_commitTimeout, cancellationToken);
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
             }
 
             stopwatch.Stop();

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/ExplicitSegmentIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/ExplicitSegmentIndexTests.cs
@@ -1,6 +1,5 @@
 using Examine;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Core.Extensions;
 using Umbraco.Cms.Search.Provider.Examine.Helpers;
@@ -383,8 +382,6 @@ public class ExplicitSegmentIndexTests : IndexTestBase
     [SetUp]
     public async Task CreateTestDocuments()
     {
-        await WaitForPackageMigrationsAsync();
-
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
             .Build();

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/ExplicitSegmentIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/ExplicitSegmentIndexTests.cs
@@ -383,8 +383,7 @@ public class ExplicitSegmentIndexTests : IndexTestBase
     [SetUp]
     public async Task CreateTestDocuments()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentProtectionIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentProtectionIndexTests.cs
@@ -84,7 +84,6 @@ public class InvariantDocumentProtectionIndexTests : IndexTestBase
     [SetUp]
     public async Task CreateInvariantDocument()
     {
-        await WaitForPackageMigrationsAsync();
         IContentType contentType = new ContentTypeBuilder()
             .WithAlias("invariant")
             .AddPropertyType()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentProtectionIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentProtectionIndexTests.cs
@@ -84,8 +84,7 @@ public class InvariantDocumentProtectionIndexTests : IndexTestBase
     [SetUp]
     public async Task CreateInvariantDocument()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
         IContentType contentType = new ContentTypeBuilder()
             .WithAlias("invariant")
             .AddPropertyType()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTests.cs
@@ -1,7 +1,6 @@
 ﻿using Examine;
 using Examine.Search;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Provider.Examine.Helpers;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -174,8 +173,6 @@ public class InvariantDocumentTests : IndexTestBase
     [SetUp]
     public async Task CreateInvariantDocument()
     {
-        await WaitForPackageMigrationsAsync();
-
         DataType dataType = new DataTypeBuilder()
             .WithId(0)
             .WithoutIdentity()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTests.cs
@@ -174,8 +174,7 @@ public class InvariantDocumentTests : IndexTestBase
     [SetUp]
     public async Task CreateInvariantDocument()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         DataType dataType = new DataTypeBuilder()
             .WithId(0)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTreeTests.Draft.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTreeTests.Draft.cs
@@ -107,8 +107,6 @@ public partial class InvariantDocumentTreeTests
 
     private async Task CreateInvariantDocumentTree(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         DataType dataType = new DataTypeBuilder()
             .WithId(0)
             .WithoutIdentity()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTreeTests.Draft.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantDocumentTreeTests.Draft.cs
@@ -107,8 +107,7 @@ public partial class InvariantDocumentTreeTests
 
     private async Task CreateInvariantDocumentTree(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         DataType dataType = new DataTypeBuilder()
             .WithId(0)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantFacetsIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantFacetsIndexTests.cs
@@ -3,7 +3,6 @@ using Examine;
 using Examine.Lucene;
 using Examine.Search;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Provider.Examine.Helpers;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -116,12 +115,6 @@ public class InvariantFacetsIndexTests : IndexTestBase
             Assert.That(firstFacet!.Value, Is.EqualTo(2));
             Assert.That(secondFacet!.Value, Is.EqualTo(2));
         });
-    }
-
-    [SetUp]
-    public async Task RunMigrations()
-    {
-        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateCountDocType()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantFacetsIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantFacetsIndexTests.cs
@@ -121,8 +121,7 @@ public class InvariantFacetsIndexTests : IndexTestBase
     [SetUp]
     public async Task RunMigrations()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateCountDocType()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantSortableIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantSortableIndexTests.cs
@@ -40,8 +40,7 @@ public class InvariantSortableIndexTests : IndexTestBase
     [SetUp]
     public async Task RunMigrations()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateTitleDocType()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantSortableIndexTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/InvariantSortableIndexTests.cs
@@ -1,7 +1,6 @@
 ﻿using Examine;
 using Examine.Search;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Provider.Examine.Helpers;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -35,12 +34,6 @@ public class InvariantSortableIndexTests : IndexTestBase
             Assert.That(values.Skip(1).First(), Is.EqualTo("B Title"));
             Assert.That(values.Last(), Is.EqualTo("C Title"));
         });
-    }
-
-    [SetUp]
-    public async Task RunMigrations()
-    {
-        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateTitleDocType()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MediaIndexServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MediaIndexServiceTests.cs
@@ -24,8 +24,7 @@ public class MediaIndexServiceTests : IndexTestBase
     [SetUp]
     public async Task RunMigrations()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateMediaAsync()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MediaIndexServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MediaIndexServiceTests.cs
@@ -21,12 +21,6 @@ public class MediaIndexServiceTests : IndexTestBase
         Assert.That(results.TotalItemCount, Is.EqualTo(1));
     }
 
-    [SetUp]
-    public async Task RunMigrations()
-    {
-        await WaitForPackageMigrationsAsync();
-    }
-
     private async Task CreateMediaAsync()
     {
         IMediaType mediaType = new MediaTypeBuilder()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MemberIndexServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MemberIndexServiceTests.cs
@@ -23,8 +23,7 @@ public class MemberIndexServiceTests : IndexTestBase
     [SetUp]
     public async Task RunMigrations()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateMemberAsync()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MemberIndexServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/MemberIndexServiceTests.cs
@@ -20,12 +20,6 @@ public class MemberIndexServiceTests : IndexTestBase
         Assert.That(results.TotalItemCount, Is.EqualTo(1));
     }
 
-    [SetUp]
-    public async Task RunMigrations()
-    {
-        await WaitForPackageMigrationsAsync();
-    }
-
     private async Task CreateMemberAsync()
     {
         IMemberType memberType = new MemberTypeBuilder()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantContentTreeTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantContentTreeTests.cs
@@ -219,8 +219,7 @@ public class VariantContentTreeTests : IndexTestBase
     [SetUp]
     public async Task CreateVariantDocumentTree()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantContentTreeTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantContentTreeTests.cs
@@ -219,8 +219,6 @@ public class VariantContentTreeTests : IndexTestBase
     [SetUp]
     public async Task CreateVariantDocumentTree()
     {
-        await WaitForPackageMigrationsAsync();
-
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
             .WithIsDefault(true)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantDocumentTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantDocumentTests.cs
@@ -160,8 +160,7 @@ public class VariantDocumentTests : IndexTestBase
     [SetUp]
     public async Task RunMigrations()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateVariantDocument()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantDocumentTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/IndexService/VariantDocumentTests.cs
@@ -1,7 +1,6 @@
 ﻿using Examine;
 using Examine.Search;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Search.Provider.Examine.Helpers;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -155,12 +154,6 @@ public class VariantDocumentTests : IndexTestBase
         Assert.That(results, Is.Not.Empty);
         var fieldName = FieldNameHelper.FieldName("body", Constants.FieldValues.Texts, segment);
         Assert.That(results.First().Values.First(x => x.Key == fieldName).Value, Is.EqualTo(expectedValue));
-    }
-
-    [SetUp]
-    public async Task RunMigrations()
-    {
-        await WaitForPackageMigrationsAsync();
     }
 
     private async Task CreateVariantDocument()

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/ContentServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/ContentServiceTests.cs
@@ -27,17 +27,16 @@ using Umbraco.Test.Search.Examine.Integration.Attributes;
 using Umbraco.Cms.Search.Provider.Examine.Services;
 using Umbraco.Test.Search.Examine.Integration.Extensions;
 using Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.IndexService;
+using Umbraco.Test.Search.Integration;
 using Constants = Umbraco.Cms.Search.Core.Constants;
 
 namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.PersistenceTests;
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-public class ContentServiceTests : UmbracoIntegrationTest
+public class ContentServiceTests : UmbracoIntegrationTestWithPackageMigrations
 {
     private bool _indexingComplete;
-
-    private IRuntimeState RuntimeState => GetRequiredService<IRuntimeState>();
 
     private IContentTypeEditingService ContentTypeEditingService => GetRequiredService<IContentTypeEditingService>();
 
@@ -171,8 +170,6 @@ public class ContentServiceTests : UmbracoIntegrationTest
 
     public async Task TestSetup(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         ContentTypeCreateModel contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType(
             "parentType",
             "Parent Type");
@@ -231,29 +228,6 @@ public class ContentServiceTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
-
-    private async Task WaitForPackageMigrationsAsync()
-    {
-        var stopWatch = Stopwatch.StartNew();
-
-        while (RuntimeState.Level != RuntimeLevel.Run)
-        {
-            if (RuntimeState.Level == RuntimeLevel.BootFailed)
-            {
-                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
-            }
-
-            if (stopWatch.ElapsedMilliseconds > 30000)
-            {
-                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
-            }
-
-            await Task.Delay(250);
-        }
-
-        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
-        await Task.Delay(500);
-    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/ContentServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/ContentServiceTests.cs
@@ -250,6 +250,9 @@ public class ContentServiceTests : UmbracoIntegrationTest
 
             await Task.Delay(250);
         }
+
+        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
+        await Task.Delay(500);
     }
 
     private static bool FieldsContainText(IndexField[] fields, string text)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/ContentServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/ContentServiceTests.cs
@@ -13,7 +13,6 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.ContentTypeEditing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.DependencyInjection;
@@ -37,8 +36,6 @@ namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.Persistence
 public class ContentServiceTests : UmbracoIntegrationTest
 {
     private bool _indexingComplete;
-
-    private PackageMigrationRunner PackageMigrationRunner => GetRequiredService<PackageMigrationRunner>();
 
     private IRuntimeState RuntimeState => GetRequiredService<IRuntimeState>();
 
@@ -174,8 +171,7 @@ public class ContentServiceTests : UmbracoIntegrationTest
 
     public async Task TestSetup(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ContentTypeCreateModel contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType(
             "parentType",
@@ -235,6 +231,26 @@ public class ContentServiceTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
+
+    private async Task WaitForPackageMigrationsAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+
+        while (RuntimeState.Level != RuntimeLevel.Run)
+        {
+            if (RuntimeState.Level == RuntimeLevel.BootFailed)
+            {
+                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
+            }
+
+            if (stopWatch.ElapsedMilliseconds > 30000)
+            {
+                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
+            }
+
+            await Task.Delay(250);
+        }
+    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/DeleteCulturesTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/DeleteCulturesTests.cs
@@ -103,8 +103,6 @@ public class DeleteCulturesTests : TestBase
     [Test]
     public async Task DeleteAllPresentCultures_CleansUpIndexDocuments()
     {
-        await WaitForPackageMigrationsAsync();
-
         var documentKey = Guid.NewGuid();
 
         // Insert a document that only has culture-specific fields (no invariant)
@@ -154,8 +152,6 @@ public class DeleteCulturesTests : TestBase
     [Test]
     public async Task DeleteCultures_CanHandleMultipleSqlPages()
     {
-        await WaitForPackageMigrationsAsync();
-
         var documentKeys = new List<Guid>();
 
         // Insert a document that only has culture-specific fields (no invariant)
@@ -204,8 +200,6 @@ public class DeleteCulturesTests : TestBase
 
     private async Task CreateVariantContent(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
             .Build();
@@ -255,8 +249,6 @@ public class DeleteCulturesTests : TestBase
 
     private async Task CreateVariantContentWithThreeCultures(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
             .Build();
@@ -312,8 +304,6 @@ public class DeleteCulturesTests : TestBase
 
     private async Task CreateInvariantAndVariantContent(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
             .Build();

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/DeleteCulturesTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/DeleteCulturesTests.cs
@@ -103,7 +103,7 @@ public class DeleteCulturesTests : TestBase
     [Test]
     public async Task DeleteAllPresentCultures_CleansUpIndexDocuments()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
+        await WaitForPackageMigrationsAsync();
 
         var documentKey = Guid.NewGuid();
 
@@ -154,7 +154,7 @@ public class DeleteCulturesTests : TestBase
     [Test]
     public async Task DeleteCultures_CanHandleMultipleSqlPages()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
+        await WaitForPackageMigrationsAsync();
 
         var documentKeys = new List<Guid>();
 
@@ -204,8 +204,7 @@ public class DeleteCulturesTests : TestBase
 
     private async Task CreateVariantContent(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
@@ -256,8 +255,7 @@ public class DeleteCulturesTests : TestBase
 
     private async Task CreateVariantContentWithThreeCultures(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")
@@ -314,8 +312,7 @@ public class DeleteCulturesTests : TestBase
 
     private async Task CreateInvariantAndVariantContent(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ILanguage langDk = new LanguageBuilder()
             .WithCultureInfo("da-DK")

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MediaServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MediaServiceTests.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.ServerEvents;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.DependencyInjection;
@@ -35,8 +34,6 @@ namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.Persistence
 public class MediaServiceTests : UmbracoIntegrationTest
 {
     private bool _indexingComplete;
-
-    private PackageMigrationRunner PackageMigrationRunner => GetRequiredService<PackageMigrationRunner>();
 
     private IRuntimeState RuntimeState => Services.GetRequiredService<IRuntimeState>();
 
@@ -146,8 +143,7 @@ public class MediaServiceTests : UmbracoIntegrationTest
 
     private async Task TestSetup()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         IMediaType mediaType = new MediaTypeBuilder()
             .WithAlias("testMediaType")
@@ -207,6 +203,26 @@ public class MediaServiceTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
+
+    private async Task WaitForPackageMigrationsAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+
+        while (RuntimeState.Level != RuntimeLevel.Run)
+        {
+            if (RuntimeState.Level == RuntimeLevel.BootFailed)
+            {
+                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
+            }
+
+            if (stopWatch.ElapsedMilliseconds > 30000)
+            {
+                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
+            }
+
+            await Task.Delay(250);
+        }
+    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MediaServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MediaServiceTests.cs
@@ -2,9 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Examine;
 using Examine.Lucene.Providers;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.HostedServices;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.ServerEvents;
@@ -21,21 +19,19 @@ using Umbraco.Cms.Search.Provider.Examine.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Test.Search.Examine.Integration.Attributes;
 using Umbraco.Test.Search.Examine.Integration.Extensions;
 using Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.IndexService;
+using Umbraco.Test.Search.Integration;
 using Constants = Umbraco.Cms.Search.Core.Constants;
 
 namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.PersistenceTests;
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-public class MediaServiceTests : UmbracoIntegrationTest
+public class MediaServiceTests : UmbracoIntegrationTestWithPackageMigrations
 {
     private bool _indexingComplete;
-
-    private IRuntimeState RuntimeState => Services.GetRequiredService<IRuntimeState>();
 
     private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
 
@@ -143,8 +139,6 @@ public class MediaServiceTests : UmbracoIntegrationTest
 
     private async Task TestSetup()
     {
-        await WaitForPackageMigrationsAsync();
-
         IMediaType mediaType = new MediaTypeBuilder()
             .WithAlias("testMediaType")
             .AddPropertyGroup()
@@ -203,29 +197,6 @@ public class MediaServiceTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
-
-    private async Task WaitForPackageMigrationsAsync()
-    {
-        var stopWatch = Stopwatch.StartNew();
-
-        while (RuntimeState.Level != RuntimeLevel.Run)
-        {
-            if (RuntimeState.Level == RuntimeLevel.BootFailed)
-            {
-                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
-            }
-
-            if (stopWatch.ElapsedMilliseconds > 30000)
-            {
-                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
-            }
-
-            await Task.Delay(250);
-        }
-
-        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
-        await Task.Delay(500);
-    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MediaServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MediaServiceTests.cs
@@ -222,6 +222,9 @@ public class MediaServiceTests : UmbracoIntegrationTest
 
             await Task.Delay(250);
         }
+
+        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
+        await Task.Delay(500);
     }
 
     private static bool FieldsContainText(IndexField[] fields, string text)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MemberServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MemberServiceTests.cs
@@ -224,6 +224,9 @@ public class MemberServiceTests : UmbracoIntegrationTest
 
             await Task.Delay(250);
         }
+
+        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
+        await Task.Delay(500);
     }
 
     private static bool FieldsContainText(IndexField[] fields, string text)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MemberServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MemberServiceTests.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.ServerEvents;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.DependencyInjection;
@@ -35,8 +34,6 @@ namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.Persistence
 public class MemberServiceTests : UmbracoIntegrationTest
 {
     private bool _indexingComplete;
-
-    private PackageMigrationRunner PackageMigrationRunner => GetRequiredService<PackageMigrationRunner>();
 
     private IRuntimeState RuntimeState => Services.GetRequiredService<IRuntimeState>();
 
@@ -144,8 +141,7 @@ public class MemberServiceTests : UmbracoIntegrationTest
 
     private async Task TestSetup()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         IMemberType memberType = new MemberTypeBuilder()
             .WithAlias("testMemberType")
@@ -209,6 +205,26 @@ public class MemberServiceTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
+
+    private async Task WaitForPackageMigrationsAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+
+        while (RuntimeState.Level != RuntimeLevel.Run)
+        {
+            if (RuntimeState.Level == RuntimeLevel.BootFailed)
+            {
+                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
+            }
+
+            if (stopWatch.ElapsedMilliseconds > 30000)
+            {
+                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
+            }
+
+            await Task.Delay(250);
+        }
+    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MemberServiceTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/MemberServiceTests.cs
@@ -2,9 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Examine;
 using Examine.Lucene.Providers;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.HostedServices;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.ServerEvents;
@@ -21,21 +19,19 @@ using Umbraco.Cms.Search.Provider.Examine.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Test.Search.Examine.Integration.Attributes;
 using Umbraco.Test.Search.Examine.Integration.Extensions;
 using Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.IndexService;
+using Umbraco.Test.Search.Integration;
 using Constants = Umbraco.Cms.Search.Core.Constants;
 
 namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.PersistenceTests;
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-public class MemberServiceTests : UmbracoIntegrationTest
+public class MemberServiceTests : UmbracoIntegrationTestWithPackageMigrations
 {
     private bool _indexingComplete;
-
-    private IRuntimeState RuntimeState => Services.GetRequiredService<IRuntimeState>();
 
     private IMemberTypeService MemberTypeService => GetRequiredService<IMemberTypeService>();
 
@@ -141,8 +137,6 @@ public class MemberServiceTests : UmbracoIntegrationTest
 
     private async Task TestSetup()
     {
-        await WaitForPackageMigrationsAsync();
-
         IMemberType memberType = new MemberTypeBuilder()
             .WithAlias("testMemberType")
             .AddPropertyGroup()
@@ -205,29 +199,6 @@ public class MemberServiceTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
-
-    private async Task WaitForPackageMigrationsAsync()
-    {
-        var stopWatch = Stopwatch.StartNew();
-
-        while (RuntimeState.Level != RuntimeLevel.Run)
-        {
-            if (RuntimeState.Level == RuntimeLevel.BootFailed)
-            {
-                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
-            }
-
-            if (stopWatch.ElapsedMilliseconds > 30000)
-            {
-                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
-            }
-
-            await Task.Delay(250);
-        }
-
-        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
-        await Task.Delay(500);
-    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
@@ -14,7 +14,6 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.ContentTypeEditing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.DependencyInjection;
 using Umbraco.Cms.Search.Core.Models.Indexing;
@@ -38,8 +37,6 @@ namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.Persistence
 public class RebuildTests : UmbracoIntegrationTest
 {
     private bool _indexingComplete;
-
-    private PackageMigrationRunner PackageMigrationRunner => GetRequiredService<PackageMigrationRunner>();
 
     private IRuntimeState RuntimeState => Services.GetRequiredService<IRuntimeState>();
 
@@ -205,8 +202,7 @@ public class RebuildTests : UmbracoIntegrationTest
     /// </summary>
     private async Task CreateContentWithPersistence(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         // Create content type
         ContentTypeCreateModel contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType(
@@ -269,6 +265,26 @@ public class RebuildTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
+
+    private async Task WaitForPackageMigrationsAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+
+        while (RuntimeState.Level != RuntimeLevel.Run)
+        {
+            if (RuntimeState.Level == RuntimeLevel.BootFailed)
+            {
+                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
+            }
+
+            if (stopWatch.ElapsedMilliseconds > 30000)
+            {
+                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
+            }
+
+            await Task.Delay(250);
+        }
+    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
@@ -23,17 +23,17 @@ using Umbraco.Cms.Search.Core.Services.ContentIndexing;
 using Umbraco.Cms.Search.Provider.Examine.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Test.Search.Examine.Integration.Attributes;
 using Umbraco.Test.Search.Examine.Integration.Extensions;
 using Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.IndexService;
+using Umbraco.Test.Search.Integration;
 using Constants = Umbraco.Cms.Search.Core.Constants;
 
 namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.PersistenceTests;
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-public class RebuildTests : UmbracoIntegrationTest
+public class RebuildTests : UmbracoIntegrationTestWithPackageMigrations
 {
     private bool _indexingComplete;
 

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Reflection;
 using Examine;
 using Examine.Lucene.Providers;
-using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.HostedServices;
@@ -37,8 +36,6 @@ namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.Persistence
 public class RebuildTests : UmbracoIntegrationTest
 {
     private bool _indexingComplete;
-
-    private IRuntimeState RuntimeState => Services.GetRequiredService<IRuntimeState>();
 
     private IContentTypeEditingService ContentTypeEditingService => GetRequiredService<IContentTypeEditingService>();
 
@@ -202,8 +199,6 @@ public class RebuildTests : UmbracoIntegrationTest
     /// </summary>
     private async Task CreateContentWithPersistence(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         // Create content type
         ContentTypeCreateModel contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType(
             "testType",
@@ -265,29 +260,6 @@ public class RebuildTests : UmbracoIntegrationTest
     }
 
     private void IndexCommited(object? sender, EventArgs e) => _indexingComplete = true;
-
-    private async Task WaitForPackageMigrationsAsync()
-    {
-        var stopWatch = Stopwatch.StartNew();
-
-        while (RuntimeState.Level != RuntimeLevel.Run)
-        {
-            if (RuntimeState.Level == RuntimeLevel.BootFailed)
-            {
-                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
-            }
-
-            if (stopWatch.ElapsedMilliseconds > 30000)
-            {
-                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
-            }
-
-            await Task.Delay(250);
-        }
-
-        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
-        await Task.Delay(500);
-    }
 
     private static bool FieldsContainText(IndexField[] fields, string text)
         => fields.Any(f =>

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/PersistenceTests/RebuildTests.cs
@@ -284,6 +284,9 @@ public class RebuildTests : UmbracoIntegrationTest
 
             await Task.Delay(250);
         }
+
+        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
+        await Task.Delay(500);
     }
 
     private static bool FieldsContainText(IndexField[] fields, string text)

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/InvariantSortingTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/InvariantSortingTests.cs
@@ -48,7 +48,7 @@ public class InvariantSortingTests : SearcherTestBase
     [TestCase(false, Direction.Ascending)]
     public async Task CanSortDecimals(bool publish, Direction direction)
     {
-        double[] doubles = [5,12412d, 0,51251d, 1.15215d, 3.251d, 2.2515125d, 125.5215d, 142.214124d];
+        double[] doubles = [5,12412d, 0,51251d, 1.15215d, 3.251d, 2.251512d, 125.5215d, 142.214124d];
         KeyValuePair<Guid, double>[] keys = (await CreateDecimalDocuments(doubles)).OrderBy(x => x.Value, direction).ToArray();
 
         var indexAlias = GetIndexAlias(publish);

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/SearcherTestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/SearcherTestBase.cs
@@ -7,10 +7,4 @@ namespace Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.SearchServi
 public abstract class SearcherTestBase : TestBase
 {
     protected ISearcher Searcher => GetRequiredService<ISearcher>();
-
-    [SetUp]
-    public async Task RunMigrations()
-    {
-        await WaitForPackageMigrationsAsync();
-    }
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/SearcherTestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ContentTests/SearchService/SearcherTestBase.cs
@@ -11,7 +11,6 @@ public abstract class SearcherTestBase : TestBase
     [SetUp]
     public async Task RunMigrations()
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
     }
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using Examine;
 using Examine.Lucene.Providers;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.HostedServices;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.ServerEvents;
@@ -14,16 +13,16 @@ using Umbraco.Cms.Search.Core.DependencyInjection;
 using Umbraco.Cms.Search.Core.NotificationHandlers;
 using Umbraco.Cms.Search.Provider.Examine.Services;
 using Umbraco.Cms.Tests.Common.Testing;
-using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Test.Search.Examine.Integration.Attributes;
 using Umbraco.Test.Search.Examine.Integration.Extensions;
 using Umbraco.Test.Search.Examine.Integration.Tests.ContentTests.IndexService;
+using Umbraco.Test.Search.Integration;
 
 namespace Umbraco.Test.Search.Examine.Integration.Tests;
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-public abstract class TestBase : UmbracoIntegrationTest
+public abstract class TestBase : UmbracoIntegrationTestWithPackageMigrations
 {
     // these tests all run against the Examine search provider, which does not care about the origin
     // of content changes, so the origin value does not matter.
@@ -119,31 +118,4 @@ public abstract class TestBase : UmbracoIntegrationTest
     }
 
     protected string GetIndexAlias(bool publish) => publish ? Cms.Search.Core.Constants.IndexAliases.PublishedContent : Cms.Search.Core.Constants.IndexAliases.DraftContent;
-
-    /// <summary>
-    /// Package migrations now run automatically on a background hosted service, so this waits for
-    /// <see cref="IRuntimeState.Level"/> to reach <see cref="RuntimeLevel.Run"/> instead of running them explicitly.
-    /// </summary>
-    protected async Task WaitForPackageMigrationsAsync()
-    {
-        var stopWatch = Stopwatch.StartNew();
-
-        while (RuntimeState.Level != RuntimeLevel.Run)
-        {
-            if (RuntimeState.Level == RuntimeLevel.BootFailed)
-            {
-                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
-            }
-
-            if (stopWatch.ElapsedMilliseconds > 30000)
-            {
-                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
-            }
-
-            await Task.Delay(250);
-        }
-
-        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
-        await Task.Delay(500);
-    }
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
@@ -148,5 +148,8 @@ public abstract class TestBase : UmbracoIntegrationTest
 
             await Task.Delay(250);
         }
+
+        // one final await, because there is a small window where even though we are now running, there is still a small window where we can lock the database.
+        await Task.Delay(500);
     }
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
@@ -95,18 +95,12 @@ public abstract class TestBase : UmbracoIntegrationTest
         var index = (LuceneIndex)GetRequiredService<IExamineManager>().GetIndex(physicalName);
         index.IndexCommitted += IndexCommited;
 
-        var hasDoneAction = false;
+        await indexUpdatingAction();
 
         var stopWatch = Stopwatch.StartNew();
 
         while (_indexingComplete is false)
         {
-            if (hasDoneAction is false)
-            {
-                await indexUpdatingAction();
-                hasDoneAction = true;
-            }
-
             if (stopWatch.ElapsedMilliseconds > TimeSpan.FromSeconds(30).TotalMilliseconds)
             {
                 throw new TimeoutException("Indexing timed out");

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
@@ -106,7 +106,7 @@ public abstract class TestBase : UmbracoIntegrationTest
                 hasDoneAction = true;
             }
 
-            if (stopWatch.ElapsedMilliseconds > 600000)
+            if (stopWatch.ElapsedMilliseconds > TimeSpan.FromSeconds(30).TotalMilliseconds)
             {
                 throw new TimeoutException("Indexing timed out");
             }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
@@ -3,12 +3,12 @@ using System.Reflection;
 using Examine;
 using Examine.Lucene.Providers;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.HostedServices;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.ServerEvents;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.Install;
 using Umbraco.Cms.Search.Core.Cache.Language;
 using Umbraco.Cms.Search.Core.DependencyInjection;
 using Umbraco.Cms.Search.Core.NotificationHandlers;
@@ -47,8 +47,6 @@ public abstract class TestBase : UmbracoIntegrationTest
     protected IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
 
     protected ILanguageService LanguageService => GetRequiredService<ILanguageService>();
-
-    protected PackageMigrationRunner PackageMigrationRunner => GetRequiredService<PackageMigrationRunner>();
 
     protected IRuntimeState RuntimeState => GetRequiredService<IRuntimeState>();
 
@@ -126,4 +124,28 @@ public abstract class TestBase : UmbracoIntegrationTest
     }
 
     protected string GetIndexAlias(bool publish) => publish ? Cms.Search.Core.Constants.IndexAliases.PublishedContent : Cms.Search.Core.Constants.IndexAliases.DraftContent;
+
+    /// <summary>
+    /// Package migrations now run automatically on a background hosted service, so this waits for
+    /// <see cref="IRuntimeState.Level"/> to reach <see cref="RuntimeLevel.Run"/> instead of running them explicitly.
+    /// </summary>
+    protected async Task WaitForPackageMigrationsAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+
+        while (RuntimeState.Level != RuntimeLevel.Run)
+        {
+            if (RuntimeState.Level == RuntimeLevel.BootFailed)
+            {
+                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", RuntimeState.BootFailedException);
+            }
+
+            if (stopWatch.ElapsedMilliseconds > 30000)
+            {
+                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {RuntimeState.Level}).");
+            }
+
+            await Task.Delay(250);
+        }
+    }
 }

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/TestBase.cs
@@ -38,7 +38,8 @@ public abstract class TestBase : UmbracoIntegrationTest
 
     protected DateTimeOffset CurrentDateTimeOffset { get; } = DateTimeOffset.Now;
 
-    protected decimal DecimalValue { get; } = 12.431167165486823626216m;
+    // Maximum value for default step in Umbraco 18+,  min=0.0 and step=0.000001
+    protected decimal DecimalValue { get; } = 12.431167m;
 
     protected IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ZeroDowntimeReindexingTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ZeroDowntimeReindexingTests.cs
@@ -360,8 +360,7 @@ public class ZeroDowntimeReindexingTests : TestBase
 
     private async Task SetUpContent(bool publish)
     {
-        await PackageMigrationRunner.RunPackageMigrationsIfPendingAsync("Umbraco CMS Search").ConfigureAwait(false);
-        Assert.That(RuntimeState.Level, Is.EqualTo(RuntimeLevel.Run));
+        await WaitForPackageMigrationsAsync();
 
         ContentTypeCreateModel contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType(
             "testZeroDowntime",

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/ZeroDowntimeReindexingTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/ZeroDowntimeReindexingTests.cs
@@ -360,8 +360,6 @@ public class ZeroDowntimeReindexingTests : TestBase
 
     private async Task SetUpContent(bool publish)
     {
-        await WaitForPackageMigrationsAsync();
-
         ContentTypeCreateModel contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType(
             "testZeroDowntime",
             "Test Zero Downtime");

--- a/src/Umbraco.Test.Search.Examine.Integration/Umbraco.Test.Search.Examine.Integration.csproj
+++ b/src/Umbraco.Test.Search.Examine.Integration/Umbraco.Test.Search.Examine.Integration.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Umbraco.Cms.Search.Provider.Examine\Umbraco.Cms.Search.Provider.Examine.csproj"/>
+    <ProjectReference Include="..\Umbraco.Test.Search.Integration\Umbraco.Test.Search.Integration.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Umbraco.Test.Search.Integration/Tests/CustomIndexDataTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/CustomIndexDataTests.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Test.Search.Integration.Tests;
 
 // This test fixture is here to ensure that we don't accidentally make it too cumbersome to index custom data.
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.None)]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerFixture)]
 public class CustomIndexDataTests : TestBase
 {
     [Test]

--- a/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/TestBase.cs
@@ -11,12 +11,11 @@ using Umbraco.Cms.Search.Core.Models.Persistence;
 using Umbraco.Cms.Search.Core.Persistence;
 using Umbraco.Cms.Search.Core.Services;
 using Umbraco.Cms.Search.Core.Services.ContentIndexing;
-using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Test.Search.Integration.Services;
 
 namespace Umbraco.Test.Search.Integration.Tests;
 
-public abstract class TestBase : UmbracoIntegrationTest
+public abstract class TestBase : UmbracoIntegrationTestWithPackageMigrations
 {
     // these tests all run against the test indexer, which does not care about the origin
     // of content changes, so the origin value does not matter unless explicitly stated

--- a/src/Umbraco.Test.Search.Integration/UmbracoIntegrationTestWithPackageMigrations.cs
+++ b/src/Umbraco.Test.Search.Integration/UmbracoIntegrationTestWithPackageMigrations.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Test.Search.Integration;
+
+public abstract class UmbracoIntegrationTestWithPackageMigrations : UmbracoIntegrationTest
+{
+    // NOTE: This works because NUnit calls base class SetUp methods before those in the derived classes.
+    //       See https://docs.nunit.org/articles/nunit/writing-tests/attributes/setup.html
+    [SetUp]
+    public async Task SetupAsync() => await WaitForPackageMigrationsAsync();
+
+    /// <summary>
+    /// Package migrations now run automatically on a background hosted service, so this waits for
+    /// <see cref="IRuntimeState.Level"/> to reach <see cref="RuntimeLevel.Run"/> instead of running them explicitly.
+    /// </summary>
+    private async Task WaitForPackageMigrationsAsync()
+    {
+        IRuntimeState runtimeState = GetRequiredService<IRuntimeState>();
+        var stopWatch = Stopwatch.StartNew();
+
+        while (runtimeState.Level != RuntimeLevel.Run)
+        {
+            if (runtimeState.Level == RuntimeLevel.BootFailed)
+            {
+                throw new InvalidOperationException("Runtime boot failed while waiting for package migrations to run.", runtimeState.BootFailedException);
+            }
+
+            if (stopWatch.ElapsedMilliseconds > 30000)
+            {
+                throw new TimeoutException($"Timed out waiting for package migrations to complete (RuntimeState.Level is currently {runtimeState.Level}).");
+            }
+
+            await Task.Delay(250);
+        }
+
+        // one final await, because there is a small window where, even though we are now running, we can still lock the database.
+        await Task.Delay(500);
+    }
+}

--- a/src/_uSync/Shared/Content/absalom-absalom.config
+++ b/src/_uSync/Shared/Content/absalom-absalom.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:12:09</CreateDate>
-    <NodeName>
+    <NodeName Default="Absalom, Absalom!">
       <Name Culture="da">Absalon, Absalon!</Name>
       <Name Culture="en-US">Absalom, Absalom!</Name>
     </NodeName>
     <SortOrder>35</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>William Faulkner</Value>
+      <Value><![CDATA[William Faulkner]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1936</Value>
+      <Value><![CDATA[1936]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En kompleks amerikanske roman, der udforsker familiebånd, sydstaternes arv og moralske skuldgivelse gennem generationer. Fortællingen krydser tid og perspektiver, når forskellige karakterer søger at løse familiens mørke hemmeligheder.</Value>
-      <Value Culture="en-US">This novel is a complex narrative about Thomas Sutpen, a poor white man who rises to power in the South, aiming to create a dynasty that would rival the old aristocratic families. However, his ambitions are thwarted by his own flawed decisions and the overarching racial and societal tensions of the era. The story is not told in a linear fashion but rather through a series of interconnected flashbacks and narratives, offering different perspectives on the same events. The book explores themes of family, class, race, and the destructive power of obsession.</Value>
+      <Value Culture="da"><![CDATA[En kompleks amerikanske roman, der udforsker familiebånd, sydstaternes arv og moralske skuldgivelse gennem generationer. Fortællingen krydser tid og perspektiver, når forskellige karakterer søger at løse familiens mørke hemmeligheder.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel is a complex narrative about Thomas Sutpen, a poor white man who rises to power in the South, aiming to create a dynasty that would rival the old aristocratic families. However, his ambitions are thwarted by his own flawed decisions and the overarching racial and societal tensions of the era. The story is not told in a linear fashion but rather through a series of interconnected flashbacks and narratives, offering different perspectives on the same events. The book explores themes of family, class, race, and the destructive power of obsession.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/adventures-of-huckleberry-finn.config
+++ b/src/_uSync/Shared/Content/adventures-of-huckleberry-finn.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:41:09</CreateDate>
-    <NodeName>
+    <NodeName Default="Adventures of Huckleberry Finn">
       <Name Culture="da">Huckleberry Finns eventyr</Name>
       <Name Culture="en-US">Adventures of Huckleberry Finn</Name>
     </NodeName>
     <SortOrder>18</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Mark Twain</Value>
+      <Value><![CDATA[Mark Twain]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1884</Value>
+      <Value><![CDATA[1884]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">Denne klassiske roman følger en ung pigedreng og en frigivet slave, som flyder ned ad Mississippi-floden på jagt efter frihed. Deres rejse er en kraftfuld skildring af venskab, moral og kampen mod undertrykkelse i det 19. århundredes Amerika.</Value>
-      <Value Culture="en-US">The novel follows the journey of a young boy named Huckleberry Finn and a runaway slave named Jim as they travel down the Mississippi River on a raft. Set in the American South before the Civil War, the story explores themes of friendship, freedom, and the hypocrisy of society. Through various adventures and encounters with a host of colorful characters, Huck grapples with his personal values, often clashing with the societal norms of the time.</Value>
+      <Value Culture="da"><![CDATA[Denne klassiske roman følger en ung pigedreng og en frigivet slave, som flyder ned ad Mississippi-floden på jagt efter frihed. Deres rejse er en kraftfuld skildring af venskab, moral og kampen mod undertrykkelse i det 19. århundredes Amerika.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel follows the journey of a young boy named Huckleberry Finn and a runaway slave named Jim as they travel down the Mississippi River on a raft. Set in the American South before the Civil War, the story explores themes of friendship, freedom, and the hypocrisy of society. Through various adventures and encounters with a host of colorful characters, Huck grapples with his personal values, often clashing with the societal norms of the time.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/alices-adventures-in-wonderland.config
+++ b/src/_uSync/Shared/Content/alices-adventures-in-wonderland.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:44:50</CreateDate>
-    <NodeName>
+    <NodeName Default="Alice's Adventures in Wonderland">
       <Name Culture="da">Alices eventyr i Eventyrland</Name>
       <Name Culture="en-US">Alice's Adventures in Wonderland</Name>
     </NodeName>
     <SortOrder>24</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Lewis Carroll</Value>
+      <Value><![CDATA[Lewis Carroll]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1865</Value>
+      <Value><![CDATA[1865]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En magisk fortælling om en ung pige, der falder ned i en kaninehul og udforsker en fantastisk verden fuldt af bizarre karakterer og absurde situationer. Romanen er kendt for sin fantastiske logik og eventyrlige eventyr.</Value>
-      <Value Culture="en-US">This novel follows the story of a young girl named Alice who falls down a rabbit hole into a fantastical world full of peculiar creatures and bizarre experiences. As she navigates through this strange land, she encounters a series of nonsensical events, including a tea party with a Mad Hatter, a pool of tears, and a trial over stolen tarts. The book is renowned for its playful use of language, logic, and its exploration of the boundaries of reality.</Value>
+      <Value Culture="da"><![CDATA[En magisk fortælling om en ung pige, der falder ned i en kaninehul og udforsker en fantastisk verden fuldt af bizarre karakterer og absurde situationer. Romanen er kendt for sin fantastiske logik og eventyrlige eventyr.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel follows the story of a young girl named Alice who falls down a rabbit hole into a fantastical world full of peculiar creatures and bizarre experiences. As she navigates through this strange land, she encounters a series of nonsensical events, including a tea party with a Mad Hatter, a pool of tears, and a trial over stolen tarts. The book is renowned for its playful use of language, logic, and its exploration of the boundaries of reality.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/animal-farm.config
+++ b/src/_uSync/Shared/Content/animal-farm.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:18:49</CreateDate>
-    <NodeName>
+    <NodeName Default="Animal Farm">
       <Name Culture="da">Gårdens Dyr</Name>
       <Name Culture="en-US">Animal Farm</Name>
     </NodeName>
     <SortOrder>44</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>George Orwell</Value>
+      <Value><![CDATA[George Orwell]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1945</Value>
+      <Value><![CDATA[1945]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En allegorisk satire, der kritiserer totalitarisme gennem historien om gårddyr, der rejser sig mod deres menneskelige mester. Romanen illustrerer, hvordan revolutionær ideologi korrupteres af magt.</Value>
-      <Value Culture="en-US">"Animal Farm" is a satirical fable set on a farm where the animals revolt, overthrow their human farmer, and take over the running of the farm for themselves. The story is an allegory of the Russian Revolution and the rise of Stalin, and the tale is told by the animals that inhabit the farm, primarily pigs who become the ruling class. Despite their initial attempts at creating an equal society, corruption and power ultimately lead to a regime as oppressive as the one they overthrew.</Value>
+      <Value Culture="da"><![CDATA[En allegorisk satire, der kritiserer totalitarisme gennem historien om gårddyr, der rejser sig mod deres menneskelige mester. Romanen illustrerer, hvordan revolutionær ideologi korrupteres af magt.]]></Value>
+      <Value Culture="en-US"><![CDATA["Animal Farm" is a satirical fable set on a farm where the animals revolt, overthrow their human farmer, and take over the running of the farm for themselves. The story is an allegory of the Russian Revolution and the rise of Stalin, and the tale is told by the animals that inhabit the farm, primarily pigs who become the ruling class. Despite their initial attempts at creating an equal society, corruption and power ultimately lead to a regime as oppressive as the one they overthrew.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/beloved.config
+++ b/src/_uSync/Shared/Content/beloved.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:19:57</CreateDate>
-    <NodeName>
+    <NodeName Default="Beloved">
       <Name Culture="da">Elsket</Name>
       <Name Culture="en-US">Beloved</Name>
     </NodeName>
     <SortOrder>46</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Toni Morrison</Value>
+      <Value><![CDATA[Toni Morrison]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1987</Value>
+      <Value><![CDATA[1987]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En dybfølende roman om en tidligere slave, der forsøger at opbygge sit liv efter slaveriets afslutning. Fortællingen, der er præget af traumatiske minder og genfund, udforsker slaveriets psykologiske og spirituelle møn.</Value>
-      <Value Culture="en-US">This novel tells the story of a former African-American slave woman who, after escaping to Ohio, is haunted by the ghost of her deceased daughter. The protagonist is forced to confront her repressed memories and the horrific realities of her past, including the desperate act she committed to protect her children from a life of slavery. The narrative is a poignant exploration of the physical, emotional, and psychological scars inflicted by the institution of slavery, and the struggle for identity and self-acceptance in its aftermath.</Value>
+      <Value Culture="da"><![CDATA[En dybfølende roman om en tidligere slave, der forsøger at opbygge sit liv efter slaveriets afslutning. Fortællingen, der er præget af traumatiske minder og genfund, udforsker slaveriets psykologiske og spirituelle møn.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel tells the story of a former African-American slave woman who, after escaping to Ohio, is haunted by the ghost of her deceased daughter. The protagonist is forced to confront her repressed memories and the horrific realities of her past, including the desperate act she committed to protect her children from a life of slavery. The narrative is a poignant exploration of the physical, emotional, and psychological scars inflicted by the institution of slavery, and the struggle for identity and self-acceptance in its aftermath.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/brave-new-world.config
+++ b/src/_uSync/Shared/Content/brave-new-world.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:14:18</CreateDate>
-    <NodeName>
+    <NodeName Default="Brave New World">
       <Name Culture="da">Nye Verden</Name>
       <Name Culture="en-US">Brave New World</Name>
     </NodeName>
     <SortOrder>39</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Aldous Huxley</Value>
+      <Value><![CDATA[Aldous Huxley]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1932</Value>
+      <Value><![CDATA[1932]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En dystopisk roman, der afbilder en futuristisk verden, hvor socialeliten bruger teknologi, medicin og psykologisk manipulation til at opretholde orden og stabilitet. Det fremviser faren ved at opgive personlig frihed for kollektiv harmoni.</Value>
-      <Value Culture="en-US">Set in a dystopian future, the novel explores a society where human beings are genetically bred and pharmaceutically conditioned to serve in a ruling order. The society is divided into five castes, each with its specific roles. The narrative follows a savage who rejects the norms of this new world order and struggles to navigate the clash between the values of his upbringing and the reality of this technologically advanced, emotionless society. His resistance prompts a deep examination of the nature of freedom, individuality, and happiness.</Value>
+      <Value Culture="da"><![CDATA[En dystopisk roman, der afbilder en futuristisk verden, hvor socialeliten bruger teknologi, medicin og psykologisk manipulation til at opretholde orden og stabilitet. Det fremviser faren ved at opgive personlig frihed for kollektiv harmoni.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in a dystopian future, the novel explores a society where human beings are genetically bred and pharmaceutically conditioned to serve in a ruling order. The society is divided into five castes, each with its specific roles. The narrative follows a savage who rejects the norms of this new world order and struggles to navigate the clash between the values of his upbringing and the reality of this technologically advanced, emotionless society. His resistance prompts a deep examination of the nature of freedom, individuality, and happiness.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/catch-22.config
+++ b/src/_uSync/Shared/Content/catch-22.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:45:46</CreateDate>
-    <NodeName>
+    <NodeName Default="Catch-22">
       <Name Culture="da">Fangst-22</Name>
       <Name Culture="en-US">Catch-22</Name>
     </NodeName>
     <SortOrder>26</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Joseph Heller</Value>
+      <Value><![CDATA[Joseph Heller]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1961</Value>
+      <Value><![CDATA[1961]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En sort komedie sat under 2. verdenskrig, hvor en american bombepiloter forsøger at undvige farlige flyveopgaver uden at blive betragtet som dum. Romanen kritiserer militærbyrokratiet og logikken i krig.</Value>
-      <Value Culture="en-US">The book is a satirical critique of military bureaucracy and the illogical nature of war, set during World War II. The story follows a U.S. Army Air Forces B-25 bombardier stationed in Italy, who is trying to maintain his sanity while fulfilling his service requirements so that he can go home. The novel explores the absurdity of war and military life through the experiences of the protagonist, who discovers that a bureaucratic rule, the "Catch-22", makes it impossible for him to escape his dangerous situation. The more he tries to avoid his military assignments, the deeper he gets sucked into the irrational world of military rule.</Value>
+      <Value Culture="da"><![CDATA[En sort komedie sat under 2. verdenskrig, hvor en american bombepiloter forsøger at undvige farlige flyveopgaver uden at blive betragtet som dum. Romanen kritiserer militærbyrokratiet og logikken i krig.]]></Value>
+      <Value Culture="en-US"><![CDATA[The book is a satirical critique of military bureaucracy and the illogical nature of war, set during World War II. The story follows a U.S. Army Air Forces B-25 bombardier stationed in Italy, who is trying to maintain his sanity while fulfilling his service requirements so that he can go home. The novel explores the absurdity of war and military life through the experiences of the protagonist, who discovers that a bureaucratic rule, the "Catch-22", makes it impossible for him to escape his dangerous situation. The more he tries to avoid his military assignments, the deeper he gets sucked into the irrational world of military rule.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/david-copperfield.config
+++ b/src/_uSync/Shared/Content/david-copperfield.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:12:49</CreateDate>
-    <NodeName>
+    <NodeName Default="David Copperfield">
       <Name Culture="da">David Copperfield</Name>
       <Name Culture="en-US">David Copperfield</Name>
     </NodeName>
     <SortOrder>36</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Charles Dickens</Value>
+      <Value><![CDATA[Charles Dickens]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1849</Value>
+      <Value><![CDATA[1849]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En episk roman, der følger livet af en mand fra barndommen til voksenliv, fuldt af eventyr, sorger og venskaber. Fortællingen udforsker tema omkring ambition, moralitet og menneskelig godhed.</Value>
-      <Value Culture="en-US">This novel follows the life of its titular protagonist from his childhood to maturity. Born to a young widow, David endures a difficult childhood when his mother remarries a harsh and abusive man. After his mother's death, he is sent to a boarding school before being forced into child labor. As he grows, David experiences hardship, love, and loss, all the while meeting a colorful array of characters. The novel is a journey of self-discovery and personal growth, showcasing the harsh realities of 19th-century England.</Value>
+      <Value Culture="da"><![CDATA[En episk roman, der følger livet af en mand fra barndommen til voksenliv, fuldt af eventyr, sorger og venskaber. Fortællingen udforsker tema omkring ambition, moralitet og menneskelig godhed.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel follows the life of its titular protagonist from his childhood to maturity. Born to a young widow, David endures a difficult childhood when his mother remarries a harsh and abusive man. After his mother's death, he is sent to a boarding school before being forced into child labor. As he grows, David experiences hardship, love, and loss, all the while meeting a colorful array of characters. The novel is a journey of self-discovery and personal growth, showcasing the harsh realities of 19th-century England.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/don-quixote.config
+++ b/src/_uSync/Shared/Content/don-quixote.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:41:52</CreateDate>
-    <NodeName>
+    <NodeName Default="Don Quixote">
       <Name Culture="da">Don Quixote</Name>
       <Name Culture="en-US">Don Quixote</Name>
     </NodeName>
     <SortOrder>7</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Miguel de Cervantes</Value>
+      <Value><![CDATA[Miguel de Cervantes]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "Spanish"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1605</Value>
+      <Value><![CDATA[1605]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En picaresque-roman om en middelaldet mand, der mister sin sind fra læsning af ridderfantasier og drager ud for at blive ridder. Hans eventyr med sin trofaste sidekick Sancho Panza er satire på romantisme og idealismer.</Value>
-      <Value Culture="en-US">This classic novel follows the adventures of a man who, driven mad by reading too many chivalric romances, decides to become a knight-errant and roam the world righting wrongs under the name Don Quixote. Accompanied by his loyal squire, Sancho Panza, he battles windmills he believes to be giants and champions the virtuous lady Dulcinea, who is in reality a simple peasant girl. The book is a richly layered critique of the popular literature of Cervantes' time and a profound exploration of reality and illusion, madness and sanity.</Value>
+      <Value Culture="da"><![CDATA[En picaresque-roman om en middelaldet mand, der mister sin sind fra læsning af ridderfantasier og drager ud for at blive ridder. Hans eventyr med sin trofaste sidekick Sancho Panza er satire på romantisme og idealismer.]]></Value>
+      <Value Culture="en-US"><![CDATA[This classic novel follows the adventures of a man who, driven mad by reading too many chivalric romances, decides to become a knight-errant and roam the world righting wrongs under the name Don Quixote. Accompanied by his loyal squire, Sancho Panza, he battles windmills he believes to be giants and champions the virtuous lady Dulcinea, who is in reality a simple peasant girl. The book is a richly layered critique of the popular literature of Cervantes' time and a profound exploration of reality and illusion, madness and sanity.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/fictions.config
+++ b/src/_uSync/Shared/Content/fictions.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:09:51</CreateDate>
-    <NodeName>
+    <NodeName Default="Fictions">
       <Name Culture="da">Fiktioner</Name>
       <Name Culture="en-US">Fictions</Name>
     </NodeName>
     <SortOrder>31</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Jorge Luis Borges</Value>
+      <Value><![CDATA[Jorge Luis Borges]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "Argentinian"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1944</Value>
+      <Value><![CDATA[1944]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En samling korte historier, der krydser grænserne for fantastiske, metafysiske og litterære eksplorationer. Henning udforsker tid, identitet og virkelighed gennem fantastiske noveller.</Value>
-      <Value Culture="en-US">"Collected Fiction" is a compilation of stories by a renowned author that takes readers on a journey through a world of philosophical paradoxes, intellectual humor, and fantastical realities. The book features a range of narratives, from complex, multi-layered tales of labyrinths and detective investigations, to metaphysical explorations of infinity and the nature of identity. It offers an immersive and thought-provoking reading experience, blurring the boundaries between reality and fiction, past and present, and the self and the universe.</Value>
+      <Value Culture="da"><![CDATA[En samling korte historier, der krydser grænserne for fantastiske, metafysiske og litterære eksplorationer. Henning udforsker tid, identitet og virkelighed gennem fantastiske noveller.]]></Value>
+      <Value Culture="en-US"><![CDATA["Collected Fiction" is a compilation of stories by a renowned author that takes readers on a journey through a world of philosophical paradoxes, intellectual humor, and fantastical realities. The book features a range of narratives, from complex, multi-layered tales of labyrinths and detective investigations, to metaphysical explorations of infinity and the nature of identity. It offers an immersive and thought-provoking reading experience, blurring the boundaries between reality and fiction, past and present, and the self and the universe.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/frankenstein.config
+++ b/src/_uSync/Shared/Content/frankenstein.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:10:59</CreateDate>
-    <NodeName>
+    <NodeName Default="Frankenstein">
       <Name Culture="da">Frankenstein</Name>
       <Name Culture="en-US">Frankenstein</Name>
     </NodeName>
     <SortOrder>33</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Mary Shelley</Value>
+      <Value><![CDATA[Mary Shelley]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1818</Value>
+      <Value><![CDATA[1818]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">Gothisk klassiker om en ung videnskabsmand, der bliver besatte med at skabe liv. Hans eksperiment resulterer i en tragisk skabelse, der søger at forstå sin tilværelse i en verden, der afviser ham.</Value>
-      <Value Culture="en-US">This classic novel tells the story of a young scientist who creates a grotesque but sentient creature in an unorthodox scientific experiment. The scientist, horrified by his creation, abandons it, leading the creature to seek revenge. The novel explores themes of ambition, responsibility, guilt, and the potential consequences of playing God.</Value>
+      <Value Culture="da"><![CDATA[Gothisk klassiker om en ung videnskabsmand, der bliver besatte med at skabe liv. Hans eksperiment resulterer i en tragisk skabelse, der søger at forstå sin tilværelse i en verden, der afviser ham.]]></Value>
+      <Value Culture="en-US"><![CDATA[This classic novel tells the story of a young scientist who creates a grotesque but sentient creature in an unorthodox scientific experiment. The scientist, horrified by his creation, abandons it, leading the creature to seek revenge. The novel explores themes of ambition, responsibility, guilt, and the potential consequences of playing God.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/gone-with-the-wind.config
+++ b/src/_uSync/Shared/Content/gone-with-the-wind.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:16:51</CreateDate>
-    <NodeName>
+    <NodeName Default="Gone With the Wind">
       <Name Culture="da">Væk med Blæsten</Name>
       <Name Culture="en-US">Gone With the Wind</Name>
     </NodeName>
     <SortOrder>40</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Margaret Mitchell</Value>
+      <Value><![CDATA[Margaret Mitchell]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1936</Value>
+      <Value><![CDATA[1936]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En episk roman, der foregår under og efter den amerikanske borgerkrig. Historien følger Scarlett OHara, en stærkvillet sydstatskvindes forsøg på at overleve krigens ødelæggelse og finde kærlighed blandt ruin.</Value>
-      <Value Culture="en-US">Set against the backdrop of the American Civil War and Reconstruction era, this novel follows the life of a young Southern belle, who is known for her beauty and charm. Her life takes a turn when she is forced to make drastic changes to survive the war and its aftermath. The story revolves around her struggle to maintain her family's plantation and her complicated love life, especially her unrequited love for a married man, and her tumultuous relationship with a roguish blockade runner.</Value>
+      <Value Culture="da"><![CDATA[En episk roman, der foregår under og efter den amerikanske borgerkrig. Historien følger Scarlett OHara, en stærkvillet sydstatskvindes forsøg på at overleve krigens ødelæggelse og finde kærlighed blandt ruin.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set against the backdrop of the American Civil War and Reconstruction era, this novel follows the life of a young Southern belle, who is known for her beauty and charm. Her life takes a turn when she is forced to make drastic changes to survive the war and its aftermath. The story revolves around her struggle to maintain her family's plantation and her complicated love life, especially her unrequited love for a married man, and her tumultuous relationship with a roguish blockade runner.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/great-expectations.config
+++ b/src/_uSync/Shared/Content/great-expectations.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:46:52</CreateDate>
-    <NodeName>
+    <NodeName Default="Great Expectations">
       <Name Culture="da">Store Forventninger</Name>
       <Name Culture="en-US">Great Expectations</Name>
     </NodeName>
     <SortOrder>28</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Charles Dickens</Value>
+      <Value><![CDATA[Charles Dickens]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1860</Value>
+      <Value><![CDATA[1860]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En dannelsesroman, der følger en ung dreng, hvis liv transformeres, da han arver formue fra en mystisk velgører. Fortællingen udforsker tema omkring ambition, ambitions tomhed og menneskelig forbindelse.</Value>
-      <Value Culture="en-US">A young orphan boy, living with his cruel older sister and her kind blacksmith husband, has an encounter with an escaped convict that changes his life. Later, he becomes the protégé of a wealthy but reclusive woman and falls in love with her adopted daughter. He then learns that an anonymous benefactor has left him a fortune, leading him to believe that his benefactor is the reclusive woman and that she intends for him to marry her adopted daughter. He moves to London to become a gentleman, but his great expectations are ultimately shattered when he learns the true identity of his benefactor and the reality of his love interest.</Value>
+      <Value Culture="da"><![CDATA[En dannelsesroman, der følger en ung dreng, hvis liv transformeres, da han arver formue fra en mystisk velgører. Fortællingen udforsker tema omkring ambition, ambitions tomhed og menneskelig forbindelse.]]></Value>
+      <Value Culture="en-US"><![CDATA[A young orphan boy, living with his cruel older sister and her kind blacksmith husband, has an encounter with an escaped convict that changes his life. Later, he becomes the protégé of a wealthy but reclusive woman and falls in love with her adopted daughter. He then learns that an anonymous benefactor has left him a fortune, leading him to believe that his benefactor is the reclusive woman and that she intends for him to marry her adopted daughter. He moves to London to become a gentleman, but his great expectations are ultimately shattered when he learns the true identity of his benefactor and the reality of his love interest.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/gullivers-travels.config
+++ b/src/_uSync/Shared/Content/gullivers-travels.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:20:44</CreateDate>
-    <NodeName>
+    <NodeName Default="Gulliver's Travels">
       <Name Culture="da">Gullivers Rejser</Name>
       <Name Culture="en-US">Gulliver's Travels</Name>
     </NodeName>
     <SortOrder>48</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Jonathan Swift</Value>
+      <Value><![CDATA[Jonathan Swift]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1726</Value>
+      <Value><![CDATA[1726]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En fantastisk rejseguide, der følger Lemuel Gulliver gennem fantastiske lande fyldt med bizarre befolkninger og eventyr. Romanen fungerer som en skarp satire på menneskeligt sociale og politiske forhold.</Value>
-      <Value Culture="en-US">This classic satire follows the travels of a surgeon and sea captain who embarks on a series of extraordinary voyages. The protagonist first finds himself shipwrecked on an island inhabited by tiny people, later discovers a land of giants, then encounters a society of intelligent horses, and finally lands on a floating island of scientists. Through these bizarre adventures, the novel explores themes of human nature, morality, and society, offering a scathing critique of European culture and the human condition.</Value>
+      <Value Culture="da"><![CDATA[En fantastisk rejseguide, der følger Lemuel Gulliver gennem fantastiske lande fyldt med bizarre befolkninger og eventyr. Romanen fungerer som en skarp satire på menneskeligt sociale og politiske forhold.]]></Value>
+      <Value Culture="en-US"><![CDATA[This classic satire follows the travels of a surgeon and sea captain who embarks on a series of extraordinary voyages. The protagonist first finds himself shipwrecked on an island inhabited by tiny people, later discovers a land of giants, then encounters a society of intelligent horses, and finally lands on a floating island of scientists. Through these bizarre adventures, the novel explores themes of human nature, morality, and society, offering a scathing critique of European culture and the human condition.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/heart-of-darkness.config
+++ b/src/_uSync/Shared/Content/heart-of-darkness.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:42:17</CreateDate>
-    <NodeName>
+    <NodeName Default="Heart of Darkness">
       <Name Culture="da">Mørkets Hjerte</Name>
       <Name Culture="en-US">Heart of Darkness</Name>
     </NodeName>
     <SortOrder>20</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Joseph Conrad</Value>
+      <Value><![CDATA[Joseph Conrad]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1899</Value>
+      <Value><![CDATA[1899]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En filosofisk novelle, der følger en søfaringsselskab på en rejse op i Congo-floden. Fortællingen udforsker imperialisme, menneskelig ondskab og grænserne mellem civilisation og barbarisme.</Value>
-      <Value Culture="en-US">This classic novel follows the journey of a seaman who travels up the Congo River into the African interior to meet a mysterious ivory trader. Throughout his journey, he encounters the harsh realities of imperialism, the brutal treatment of native Africans, and the depths of human cruelty and madness. The protagonist's journey into the 'heart of darkness' serves as both a physical exploration of the African continent and a metaphorical exploration into the depths of human nature.</Value>
+      <Value Culture="da"><![CDATA[En filosofisk novelle, der følger en søfaringsselskab på en rejse op i Congo-floden. Fortællingen udforsker imperialisme, menneskelig ondskab og grænserne mellem civilisation og barbarisme.]]></Value>
+      <Value Culture="en-US"><![CDATA[This classic novel follows the journey of a seaman who travels up the Congo River into the African interior to meet a mysterious ivory trader. Throughout his journey, he encounters the harsh realities of imperialism, the brutal treatment of native Africans, and the depths of human cruelty and madness. The protagonist's journey into the 'heart of darkness' serves as both a physical exploration of the African continent and a metaphorical exploration into the depths of human nature.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/in-search-of-lost-time.config
+++ b/src/_uSync/Shared/Content/in-search-of-lost-time.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:37:11</CreateDate>
-    <NodeName>
+    <NodeName Default="In Search of Lost Time">
       <Name Culture="da">På Sporet af den tabte Tid</Name>
       <Name Culture="en-US">In Search of Lost Time</Name>
     </NodeName>
     <SortOrder>1</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Marcel Proust</Value>
+      <Value><![CDATA[Marcel Proust]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Long</Value>
+      <Value><![CDATA[Very Long]]></Value>
     </length>
     <publishYear>
-      <Value>1913</Value>
+      <Value><![CDATA[1913]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">Et monumentalt værk af litterær modernisme, der udforsker tid, hukommelse og menneskelig erfaring gennem detaljerede refleksioner om livet. Romanen kilder væsentlige temaer omkring kærlighed, kunst og mødet med fortiden.</Value>
-      <Value Culture="en-US">This renowned novel is a sweeping exploration of memory, love, art, and the passage of time, told through the narrator's recollections of his childhood and experiences into adulthood in the late 19th and early 20th century aristocratic France. The narrative is notable for its lengthy and intricate involuntary memory episodes, the most famous being the "madeleine episode". It explores the themes of time, space and memory, but also raises questions about the nature of art and literature, and the complex relationships between love, sexuality, and possession.</Value>
+      <Value Culture="da"><![CDATA[Et monumentalt værk af litterær modernisme, der udforsker tid, hukommelse og menneskelig erfaring gennem detaljerede refleksioner om livet. Romanen kilder væsentlige temaer omkring kærlighed, kunst og mødet med fortiden.]]></Value>
+      <Value Culture="en-US"><![CDATA[This renowned novel is a sweeping exploration of memory, love, art, and the passage of time, told through the narrator's recollections of his childhood and experiences into adulthood in the late 19th and early 20th century aristocratic France. The narrative is notable for its lengthy and intricate involuntary memory episodes, the most famous being the "madeleine episode". It explores the themes of time, space and memory, but also raises questions about the nature of art and literature, and the complex relationships between love, sexuality, and possession.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/invisible-man.config
+++ b/src/_uSync/Shared/Content/invisible-man.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:45:18</CreateDate>
-    <NodeName>
+    <NodeName Default="Invisible Man">
       <Name Culture="da">Den Usynlige Mand</Name>
       <Name Culture="en-US">Invisible Man</Name>
     </NodeName>
     <SortOrder>25</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Ralph Ellison</Value>
+      <Value><![CDATA[Ralph Ellison]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1952</Value>
+      <Value><![CDATA[1952]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En surrealistisk roman om en mand, der bliver usynlig og må navigere en verden, der enten ignorerer eller misbrugerer ham. Fortællingen er en metafor for sortes oplevelse af marginalisering i Amerika.</Value>
-      <Value Culture="en-US">The novel is a poignant exploration of a young African-American man's journey through life, where he grapples with issues of race, identity, and individuality in mid-20th-century America. The protagonist, who remains unnamed throughout the story, considers himself socially invisible due to his race. The narrative follows his experiences from the South to the North, from being a student to a worker, and his involvement in the Brotherhood, a political organization. The book is a profound critique of societal norms and racial prejudice, highlighting the protagonist's struggle to assert his identity in a world that refuses to see him.</Value>
+      <Value Culture="da"><![CDATA[En surrealistisk roman om en mand, der bliver usynlig og må navigere en verden, der enten ignorerer eller misbrugerer ham. Fortællingen er en metafor for sortes oplevelse af marginalisering i Amerika.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel is a poignant exploration of a young African-American man's journey through life, where he grapples with issues of race, identity, and individuality in mid-20th-century America. The protagonist, who remains unnamed throughout the story, considers himself socially invisible due to his race. The narrative follows his experiences from the South to the North, from being a student to a worker, and his involvement in the Brotherhood, a political organization. The book is a profound critique of societal norms and racial prejudice, highlighting the protagonist's struggle to assert his identity in a world that refuses to see him.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/jane-eyre.config
+++ b/src/_uSync/Shared/Content/jane-eyre.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:42:49</CreateDate>
-    <NodeName>
+    <NodeName Default="Jane Eyre">
       <Name Culture="da">Jane Eyre</Name>
       <Name Culture="en-US">Jane Eyre</Name>
     </NodeName>
     <SortOrder>21</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Charlotte Brontë</Value>
+      <Value><![CDATA[Charlotte Brontë]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1847</Value>
+      <Value><![CDATA[1847]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En gothisk-romantisk roman om en ung kvinde, der søger uafhængighed og selvværd i en verden, der forsøger at tvinge hende til underkastelse. Hendes forhold til den hemmelighedsfulde Mr. Rochester driver historien fremad.</Value>
-      <Value Culture="en-US">The novel follows the life of Jane Eyre, an orphan who is mistreated by her relatives and sent to a charity school. As she grows up, Jane becomes a governess at Thornfield Hall, where she falls in love with the brooding and mysterious Mr. Rochester. However, she soon learns of a dark secret in his past that threatens their future together. The story is a profound exploration of a woman's self-discovery and her struggle for independence and love in a rigid Victorian society.</Value>
+      <Value Culture="da"><![CDATA[En gothisk-romantisk roman om en ung kvinde, der søger uafhængighed og selvværd i en verden, der forsøger at tvinge hende til underkastelse. Hendes forhold til den hemmelighedsfulde Mr. Rochester driver historien fremad.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel follows the life of Jane Eyre, an orphan who is mistreated by her relatives and sent to a charity school. As she grows up, Jane becomes a governess at Thornfield Hall, where she falls in love with the brooding and mysterious Mr. Rochester. However, she soon learns of a dark secret in his past that threatens their future together. The story is a profound exploration of a woman's self-discovery and her struggle for independence and love in a rigid Victorian society.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/journey-to-the-end-of-the-night.config
+++ b/src/_uSync/Shared/Content/journey-to-the-end-of-the-night.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:13:22</CreateDate>
-    <NodeName>
+    <NodeName Default="Journey to the End of The Night">
       <Name Culture="da">Rejse til Nattens Ende</Name>
       <Name Culture="en-US">Journey to the End of The Night</Name>
     </NodeName>
     <SortOrder>37</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Louis-Ferdinand Céline</Value>
+      <Value><![CDATA[Louis-Ferdinand Céline]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1932</Value>
+      <Value><![CDATA[1932]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En modernistisk roman, der følger en mands nihilistiske rejse gennem verden under og efter 1. verdenskrig. Fortællingen er en bitter skildring af menneskelig eksistens og civilisationens illusioner.</Value>
-      <Value Culture="en-US">The novel is a semi-autobiographical work that explores the harsh realities of life through the cynical and disillusioned eyes of the protagonist. The narrative follows his experiences from the trenches of World War I, through the African jungles, to the streets of America and the slums of Paris, showcasing the horrors of war, colonialism, and the dark side of human nature. The protagonist's journey is marked by his struggle with despair, loneliness, and the absurdity of existence, offering a bleak yet profound commentary on the human condition.</Value>
+      <Value Culture="da"><![CDATA[En modernistisk roman, der følger en mands nihilistiske rejse gennem verden under og efter 1. verdenskrig. Fortællingen er en bitter skildring af menneskelig eksistens og civilisationens illusioner.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel is a semi-autobiographical work that explores the harsh realities of life through the cynical and disillusioned eyes of the protagonist. The narrative follows his experiences from the trenches of World War I, through the African jungles, to the streets of America and the slums of Paris, showcasing the horrors of war, colonialism, and the dark side of human nature. The protagonist's journey is marked by his struggle with despair, loneliness, and the absurdity of existence, offering a bleak yet profound commentary on the human condition.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/les-misérables.config
+++ b/src/_uSync/Shared/Content/les-misérables.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:46:19</CreateDate>
-    <NodeName>
+    <NodeName Default="Les Misérables">
       <Name Culture="da">Les Misérables</Name>
       <Name Culture="en-US">Les Misérables</Name>
     </NodeName>
     <SortOrder>27</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Victor Hugo</Value>
+      <Value><![CDATA[Victor Hugo]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Long</Value>
+      <Value><![CDATA[Very Long]]></Value>
     </length>
     <publishYear>
-      <Value>1862</Value>
+      <Value><![CDATA[1862]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En episk roman sat i 19. århundredes Frankrig, der følger en frigivet fange gennem et liv af genvordigheder og indre reformation. Fortællingen integrerer sociale kommentarer, dødelighed og menneskelig godhed.</Value>
-      <Value Culture="en-US">Set in early 19th-century France, the narrative follows the lives and interactions of several characters, particularly the struggles of ex-convict Jean Valjean and his journey towards redemption. The story touches upon the nature of law and grace, and elaborates upon the history of France, architecture of Paris, politics, moral philosophy, antimonarchism, justice, religion, and the types and nature of romantic and familial love. It is known for its vivid and relatable characters, and its exploration of societal and moral issues.</Value>
+      <Value Culture="da"><![CDATA[En episk roman sat i 19. århundredes Frankrig, der følger en frigivet fange gennem et liv af genvordigheder og indre reformation. Fortællingen integrerer sociale kommentarer, dødelighed og menneskelig godhed.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in early 19th-century France, the narrative follows the lives and interactions of several characters, particularly the struggles of ex-convict Jean Valjean and his journey towards redemption. The story touches upon the nature of law and grace, and elaborates upon the history of France, architecture of Paris, politics, moral philosophy, antimonarchism, justice, religion, and the types and nature of romantic and familial love. It is known for its vivid and relatable characters, and its exploration of societal and moral issues.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/lolita.config
+++ b/src/_uSync/Shared/Content/lolita.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:42:22</CreateDate>
-    <NodeName>
+    <NodeName Default="Lolita">
       <Name Culture="da">Lolita</Name>
       <Name Culture="en-US">Lolita</Name>
     </NodeName>
     <SortOrder>8</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Vladimir Nabokov</Value>
+      <Value><![CDATA[Vladimir Nabokov]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1955</Value>
+      <Value><![CDATA[1955]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En kontroversiel roman, der fortælles af en voksen mand, der bliver obsessiv over en ung pige. Værket udforsker manipulering, kunstig besvogning og læserens moralske ubehag på kreativ vis.</Value>
-      <Value Culture="en-US">The novel tells the story of Humbert Humbert, a man with a disturbing obsession for young girls, or "nymphets" as he calls them. His obsession leads him to engage in a manipulative and destructive relationship with his 12-year-old stepdaughter, Lolita. The narrative is a controversial exploration of manipulation, obsession, and unreliable narration, as Humbert attempts to justify his actions and feelings throughout the story.</Value>
+      <Value Culture="da"><![CDATA[En kontroversiel roman, der fortælles af en voksen mand, der bliver obsessiv over en ung pige. Værket udforsker manipulering, kunstig besvogning og læserens moralske ubehag på kreativ vis.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel tells the story of Humbert Humbert, a man with a disturbing obsession for young girls, or "nymphets" as he calls them. His obsession leads him to engage in a manipulative and destructive relationship with his 12-year-old stepdaughter, Lolita. The narrative is a controversial exploration of manipulation, obsession, and unreliable narration, as Humbert attempts to justify his actions and feelings throughout the story.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/lord-of-the-flies.config
+++ b/src/_uSync/Shared/Content/lord-of-the-flies.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:13:50</CreateDate>
-    <NodeName>
+    <NodeName Default="Lord of the Flies">
       <Name Culture="da">Fluernes Herre</Name>
       <Name Culture="en-US">Lord of the Flies</Name>
     </NodeName>
     <SortOrder>38</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>William Golding</Value>
+      <Value><![CDATA[William Golding]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1954</Value>
+      <Value><![CDATA[1954]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En allegorisk roman om en gruppe drenge, der strandet på en øde ø, forsøger at opbygge et samfund. Fortællingen udforsker menneskets inhærent ondskab og civilization over animalske instinkter.</Value>
-      <Value Culture="en-US">A group of British boys are stranded on an uninhabited island after their plane crashes during wartime. Initially, they attempt to establish order, creating rules and electing a leader. However, as time passes, their civility erodes, and they descend into savagery and chaos. The struggle for power intensifies, leading to violence and death. The novel explores themes of innocence, the inherent evil in mankind, and the thin veneer of civilization.</Value>
+      <Value Culture="da"><![CDATA[En allegorisk roman om en gruppe drenge, der strandet på en øde ø, forsøger at opbygge et samfund. Fortællingen udforsker menneskets inhærent ondskab og civilization over animalske instinkter.]]></Value>
+      <Value Culture="en-US"><![CDATA[A group of British boys are stranded on an uninhabited island after their plane crashes during wartime. Initially, they attempt to establish order, creating rules and electing a leader. However, as time passes, their civility erodes, and they descend into savagery and chaos. The struggle for power intensifies, leading to violence and death. The novel explores themes of innocence, the inherent evil in mankind, and the thin veneer of civilization.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/madame-bovary.config
+++ b/src/_uSync/Shared/Content/madame-bovary.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:39:34</CreateDate>
-    <NodeName>
+    <NodeName Default="Madame Bovary">
       <Name Culture="da">Fru Bovary</Name>
       <Name Culture="en-US">Madame Bovary</Name>
     </NodeName>
     <SortOrder>15</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Gustave Flaubert</Value>
+      <Value><![CDATA[Gustave Flaubert]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1857</Value>
+      <Value><![CDATA[1857]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En realistisk meisterværk om en provinsmand, hvis romantiske fantasi og utroskab fører til hendes egen ødelæggelse. Romanen er en kritik af kvindeligt ideal og tankeløs romantisme.</Value>
-      <Value Culture="en-US">Madame Bovary is a tragic novel about a young woman, Emma Bovary, who is married to a dull, but kind-hearted doctor. Dissatisfied with her life, she embarks on a series of extramarital affairs and indulges in a luxurious lifestyle in an attempt to escape the banalities and emptiness of provincial life. Her desire for passion and excitement leads her down a path of financial ruin and despair, ultimately resulting in a tragic end.</Value>
+      <Value Culture="da"><![CDATA[En realistisk meisterværk om en provinsmand, hvis romantiske fantasi og utroskab fører til hendes egen ødelæggelse. Romanen er en kritik af kvindeligt ideal og tankeløs romantisme.]]></Value>
+      <Value Culture="en-US"><![CDATA[Madame Bovary is a tragic novel about a young woman, Emma Bovary, who is married to a dull, but kind-hearted doctor. Dissatisfied with her life, she embarks on a series of extramarital affairs and indulges in a luxurious lifestyle in an attempt to escape the banalities and emptiness of provincial life. Her desire for passion and excitement leads her down a path of financial ruin and despair, ultimately resulting in a tragic end.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/middlemarch.config
+++ b/src/_uSync/Shared/Content/middlemarch.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:43:22</CreateDate>
-    <NodeName>
+    <NodeName Default="Middlemarch">
       <Name Culture="da">Middlemarch</Name>
       <Name Culture="en-US">Middlemarch</Name>
     </NodeName>
     <SortOrder>22</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>George Eliot</Value>
+      <Value><![CDATA[George Eliot]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1871</Value>
+      <Value><![CDATA[1871]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En kompleks roman om livet i et provinsialt engelsk samfund, der følger flere karakterer gennem valg, ambitioner og skuffelser. Værket udforsker menneskelig vedblivelse, kærlighed og sociale forventninger.</Value>
-      <Value Culture="en-US">Set in the fictitious English town of Middlemarch during the early 19th century, the novel explores the complex web of relationships in a close-knit society. It follows the lives of several characters, primarily Dorothea Brooke, a young woman of idealistic fervor, and Tertius Lydgate, an ambitious young doctor, who both grapple with societal expectations, personal desires, and moral dilemmas. Their stories intertwine with a rich tapestry of other townsfolk, reflecting themes of love, marriage, ambition, and reform, making a profound commentary on the human condition.</Value>
+      <Value Culture="da"><![CDATA[En kompleks roman om livet i et provinsialt engelsk samfund, der følger flere karakterer gennem valg, ambitioner og skuffelser. Værket udforsker menneskelig vedblivelse, kærlighed og sociale forventninger.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in the fictitious English town of Middlemarch during the early 19th century, the novel explores the complex web of relationships in a close-knit society. It follows the lives of several characters, primarily Dorothea Brooke, a young woman of idealistic fervor, and Tertius Lydgate, an ambitious young doctor, who both grapple with societal expectations, personal desires, and moral dilemmas. Their stories intertwine with a rich tapestry of other townsfolk, reflecting themes of love, marriage, ambition, and reform, making a profound commentary on the human condition.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/moby-dick.config
+++ b/src/_uSync/Shared/Content/moby-dick.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:41:20</CreateDate>
-    <NodeName>
+    <NodeName Default="Moby-Dick">
       <Name Culture="da">Moby Dick</Name>
       <Name Culture="en-US">Moby-Dick</Name>
     </NodeName>
     <SortOrder>6</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Herman Melville</Value>
+      <Value><![CDATA[Herman Melville]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1851</Value>
+      <Value><![CDATA[1851]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En episk eventyr om Captain Ahab's besatte jagten på hvalpen, der tog hans ben. Fortællingen kombinerer højtflygt litteratur, naturhistorie og filosofisk meditation om menneskets forhold til naturen.</Value>
-      <Value Culture="en-US">The novel is a detailed narrative of a vengeful sea captain's obsessive quest to hunt down a giant white sperm whale that bit off his leg. The captain's relentless pursuit, despite the warnings and concerns of his crew, leads them on a dangerous journey across the seas. The story is a complex exploration of good and evil, obsession, and the nature of reality, filled with rich descriptions of whaling and the sea.</Value>
+      <Value Culture="da"><![CDATA[En episk eventyr om Captain Ahab's besatte jagten på hvalpen, der tog hans ben. Fortællingen kombinerer højtflygt litteratur, naturhistorie og filosofisk meditation om menneskets forhold til naturen.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel is a detailed narrative of a vengeful sea captain's obsessive quest to hunt down a giant white sperm whale that bit off his leg. The captain's relentless pursuit, despite the warnings and concerns of his crew, leads them on a dangerous journey across the seas. The story is a complex exploration of good and evil, obsession, and the nature of reality, filled with rich descriptions of whaling and the sea.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/mrs.dalloway.config
+++ b/src/_uSync/Shared/Content/mrs.dalloway.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:47:25</CreateDate>
-    <NodeName>
+    <NodeName Default="Mrs. Dalloway">
       <Name Culture="da">Fru Dalloway</Name>
       <Name Culture="en-US">Mrs. Dalloway</Name>
     </NodeName>
     <SortOrder>29</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Virginia Woolf</Value>
+      <Value><![CDATA[Virginia Woolf]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1925</Value>
+      <Value><![CDATA[1925]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En modernistisk roman, der udforsker en enkelt dag i en kvindes liv gennem indre tankestrøm og minder. Fortællingen udforsker tid, identitet og menneskets søgen efter betydning.</Value>
-      <Value Culture="en-US">The novel chronicles a day in the life of Clarissa Dalloway, a high-society woman in post-World War I England, as she prepares for a party she is hosting that evening. Throughout the day, she encounters various characters from her past, including a former suitor and a shell-shocked war veteran. The narrative jumps back and forth in time and in and out of different characters' minds, exploring themes of mental illness, existentialism, and the nature of time.</Value>
+      <Value Culture="da"><![CDATA[En modernistisk roman, der udforsker en enkelt dag i en kvindes liv gennem indre tankestrøm og minder. Fortællingen udforsker tid, identitet og menneskets søgen efter betydning.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel chronicles a day in the life of Clarissa Dalloway, a high-society woman in post-World War I England, as she prepares for a party she is hosting that evening. Throughout the day, she encounters various characters from her past, including a former suitor and a shell-shocked war veteran. The narrative jumps back and forth in time and in and out of different characters' minds, exploring themes of mental illness, existentialism, and the nature of time.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/nineteen-eighty-four.config
+++ b/src/_uSync/Shared/Content/nineteen-eighty-four.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:40:40</CreateDate>
-    <NodeName>
+    <NodeName Default="Nineteen Eighty Four">
       <Name Culture="da">1984</Name>
       <Name Culture="en-US">Nineteen Eighty Four</Name>
     </NodeName>
     <SortOrder>5</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>George Orwell</Value>
+      <Value><![CDATA[George Orwell]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1949</Value>
+      <Value><![CDATA[1949]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En dystopisk roman om et totalitært regimes kontrol over menneskesindet gennem propaganda og overvågning. Fortællingen er en advarsel om faren ved autoritarisme og manipulering af virkelighed.</Value>
-      <Value Culture="en-US">Set in a dystopian future, the novel presents a society under the total control of a totalitarian regime, led by the omnipresent Big Brother. The protagonist, a low-ranking member of 'the Party', begins to question the regime and falls in love with a woman, an act of rebellion in a world where independent thought, dissent, and love are prohibited. The novel explores themes of surveillance, censorship, and the manipulation of truth.</Value>
+      <Value Culture="da"><![CDATA[En dystopisk roman om et totalitært regimes kontrol over menneskesindet gennem propaganda og overvågning. Fortællingen er en advarsel om faren ved autoritarisme og manipulering af virkelighed.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in a dystopian future, the novel presents a society under the total control of a totalitarian regime, led by the omnipresent Big Brother. The protagonist, a low-ranking member of 'the Party', begins to question the regime and falls in love with a woman, an act of rebellion in a world where independent thought, dissent, and love are prohibited. The novel explores themes of surveillance, censorship, and the manipulation of truth.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/on-the-road.config
+++ b/src/_uSync/Shared/Content/on-the-road.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:10:30</CreateDate>
-    <NodeName>
+    <NodeName Default="On the Road">
       <Name Culture="da">På Vej</Name>
       <Name Culture="en-US">On the Road</Name>
     </NodeName>
     <SortOrder>32</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Jack Kerouac</Value>
+      <Value><![CDATA[Jack Kerouac]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1957</Value>
+      <Value><![CDATA[1957]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En moderne klassiker om unges søgen efter frihed, autentisitet og spirituel opfyldelse gennem rejser over Amerika. Romanen opfangede spiritus i Beat-generationen.</Value>
-      <Value Culture="en-US">This novel follows the story of a young man and his friend as they embark on a series of cross-country road trips across America during the late 1940s and early 1950s. The protagonist, driven by a desire for freedom and a quest for identity, encounters a series of eccentric characters and experiences the highs and lows of the Beat Generation. The narrative is a testament to the restlessness of youth and the allure of adventure, underscored by themes of jazz, poetry, and drug use.</Value>
+      <Value Culture="da"><![CDATA[En moderne klassiker om unges søgen efter frihed, autentisitet og spirituel opfyldelse gennem rejser over Amerika. Romanen opfangede spiritus i Beat-generationen.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel follows the story of a young man and his friend as they embark on a series of cross-country road trips across America during the late 1940s and early 1950s. The protagonist, driven by a desire for freedom and a quest for identity, encounters a series of eccentric characters and experiences the highs and lows of the Beat Generation. The narrative is a testament to the restlessness of youth and the allure of adventure, underscored by themes of jazz, poetry, and drug use.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/one-hundred-years-of-solitude.config
+++ b/src/_uSync/Shared/Content/one-hundred-years-of-solitude.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:39:27</CreateDate>
-    <NodeName>
+    <NodeName Default="One Hundred Years of Solitude">
       <Name Culture="da">Hundrede År af Ensomhed</Name>
       <Name Culture="en-US">One Hundred Years of Solitude</Name>
     </NodeName>
     <SortOrder>3</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Gabriel García Márquez</Value>
+      <Value><![CDATA[Gabriel García Márquez]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "Colombian"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1967</Value>
+      <Value><![CDATA[1967]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En magisk realisme meisterværk, der følger en familie gennem syv generationer i den isolerede landsby Macondo. Fortællingen blander fantastiske elementi med menneskelige skildringer af kærlighed, krig og cyklisk fattigdom.</Value>
-      <Value Culture="en-US">This novel is a multi-generational saga that focuses on the Buendía family, who founded the fictional town of Macondo. It explores themes of love, loss, family, and the cyclical nature of history. The story is filled with magical realism, blending the supernatural with the ordinary, as it chronicles the family's experiences, including civil war, marriages, births, and deaths. The book is renowned for its narrative style and its exploration of solitude, fate, and the inevitability of repetition in history.</Value>
+      <Value Culture="da"><![CDATA[En magisk realisme meisterværk, der følger en familie gennem syv generationer i den isolerede landsby Macondo. Fortællingen blander fantastiske elementi med menneskelige skildringer af kærlighed, krig og cyklisk fattigdom.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel is a multi-generational saga that focuses on the Buendía family, who founded the fictional town of Macondo. It explores themes of love, loss, family, and the cyclical nature of history. The story is filled with magical realism, blending the supernatural with the ordinary, as it chronicles the family's experiences, including civil war, marriages, births, and deaths. The book is renowned for its narrative style and its exploration of solitude, fate, and the inevitability of repetition in history.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/pride-and-prejudice.config
+++ b/src/_uSync/Shared/Content/pride-and-prejudice.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:44:18</CreateDate>
-    <NodeName>
+    <NodeName Default="Pride and Prejudice">
       <Name Culture="da">Stolthed og Fordom</Name>
       <Name Culture="en-US">Pride and Prejudice</Name>
     </NodeName>
     <SortOrder>11</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Jane Austen</Value>
+      <Value><![CDATA[Jane Austen]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1813</Value>
+      <Value><![CDATA[1813]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En romantisk komedie sat i tidlig 19. århundredes England, der følger Elizabeth Bennet's komplekse forhold til den stolte Mr. Darcy. Romanen udforsker tema omkring kærlighed, klasse og personlige fordømme.</Value>
-      <Value Culture="en-US">Set in early 19th-century England, this classic novel revolves around the lives of the Bennet family, particularly the five unmarried daughters. The narrative explores themes of manners, upbringing, morality, education, and marriage within the society of the landed gentry. It follows the romantic entanglements of Elizabeth Bennet, the second eldest daughter, who is intelligent, lively, and quick-witted, and her tumultuous relationship with the proud, wealthy, and seemingly aloof Mr. Darcy. Their story unfolds as they navigate societal expectations, personal misunderstandings, and their own pride and prejudice.</Value>
+      <Value Culture="da"><![CDATA[En romantisk komedie sat i tidlig 19. århundredes England, der følger Elizabeth Bennet's komplekse forhold til den stolte Mr. Darcy. Romanen udforsker tema omkring kærlighed, klasse og personlige fordømme.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in early 19th-century England, this classic novel revolves around the lives of the Bennet family, particularly the five unmarried daughters. The narrative explores themes of manners, upbringing, morality, education, and marriage within the society of the landed gentry. It follows the romantic entanglements of Elizabeth Bennet, the second eldest daughter, who is intelligent, lively, and quick-witted, and her tumultuous relationship with the proud, wealthy, and seemingly aloof Mr. Darcy. Their story unfolds as they navigate societal expectations, personal misunderstandings, and their own pride and prejudice.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/rebecca.config
+++ b/src/_uSync/Shared/Content/rebecca.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:21:10</CreateDate>
-    <NodeName>
+    <NodeName Default="Rebecca">
       <Name Culture="da">Rebecca</Name>
       <Name Culture="en-US">Rebecca</Name>
     </NodeName>
     <SortOrder>49</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Daphne du Maurier</Value>
+      <Value><![CDATA[Daphne du Maurier]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1938</Value>
+      <Value><![CDATA[1938]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En gothisk-suspensefuld roman om en ung kvindes frygt for hendes mands hendes hustruer. Forbipasserinden er præget af mønster, hemmeligheder og hendes forgængers uforvarende tilstedeværelse.</Value>
-      <Value Culture="en-US">A young woman marries a wealthy widower and moves into his large English country house. She quickly realizes that the memory of her husband's first wife, Rebecca, haunts every corner of the estate. The housekeeper's obsessive devotion to Rebecca and the mysterious circumstances of her death continue to overshadow the second wife's attempts to make a happy life with her husband. As secrets about Rebecca's life and death are revealed, the new wife must grapple with her own identity and place within the household.</Value>
+      <Value Culture="da"><![CDATA[En gothisk-suspensefuld roman om en ung kvindes frygt for hendes mands hendes hustruer. Forbipasserinden er præget af mønster, hemmeligheder og hendes forgængers uforvarende tilstedeværelse.]]></Value>
+      <Value Culture="en-US"><![CDATA[A young woman marries a wealthy widower and moves into his large English country house. She quickly realizes that the memory of her husband's first wife, Rebecca, haunts every corner of the estate. The housekeeper's obsessive devotion to Rebecca and the mysterious circumstances of her death continue to overshadow the second wife's attempts to make a happy life with her husband. As secrets about Rebecca's life and death are revealed, the new wife must grapple with her own identity and place within the household.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-catcher-in-the-rye.config
+++ b/src/_uSync/Shared/Content/the-catcher-in-the-rye.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:40:11</CreateDate>
-    <NodeName>
+    <NodeName Default="The Catcher in the Rye">
       <Name Culture="da">Rug i Øjet</Name>
       <Name Culture="en-US">The Catcher in the Rye</Name>
     </NodeName>
     <SortOrder>4</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>J. D. Salinger</Value>
+      <Value><![CDATA[J. D. Salinger]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1951</Value>
+      <Value><![CDATA[1951]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En ikonisk roman om en adolescent dreng, der oplever et sammenbrud efter at blive kastet ud af sin eliteinternat. Fortællingen udforsker alienation, uskyld og søgen efter autentisitet i voksenverden.</Value>
-      <Value Culture="en-US">The novel follows the story of a teenager named Holden Caulfield, who has just been expelled from his prep school. The narrative unfolds over the course of three days, during which Holden experiences various forms of alienation and his mental state continues to unravel. He criticizes the adult world as "phony" and struggles with his own transition into adulthood. The book is a profound exploration of teenage rebellion, alienation, and the loss of innocence.</Value>
+      <Value Culture="da"><![CDATA[En ikonisk roman om en adolescent dreng, der oplever et sammenbrud efter at blive kastet ud af sin eliteinternat. Fortællingen udforsker alienation, uskyld og søgen efter autentisitet i voksenverden.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel follows the story of a teenager named Holden Caulfield, who has just been expelled from his prep school. The narrative unfolds over the course of three days, during which Holden experiences various forms of alienation and his mental state continues to unravel. He criticizes the adult world as "phony" and struggles with his own transition into adulthood. The book is a profound exploration of teenage rebellion, alienation, and the loss of innocence.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-golden-notebook.config
+++ b/src/_uSync/Shared/Content/the-golden-notebook.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:18:18</CreateDate>
-    <NodeName>
+    <NodeName Default="The Golden Notebook">
       <Name Culture="da">Den Gyldne Notesbog</Name>
       <Name Culture="en-US">The Golden Notebook</Name>
     </NodeName>
     <SortOrder>43</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Doris May Lessing</Value>
+      <Value><![CDATA[Doris May Lessing]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1962</Value>
+      <Value><![CDATA[1962]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En eksperimentel roman om en kvindelig forfatter, der bruger fem notesbøger til at udforsker forskellige aspekter af hendes liv. Værket er en feministisk meditation om kvinders oplevelser og indre liv.</Value>
-      <Value Culture="en-US">The novel centers around a woman named Anna Wulf, a writer who keeps four notebooks, each representing a different aspect of her life: her experiences in Africa, her current life in London, a novel she is writing, and her personal experiences. As Anna's mental state deteriorates, she attempts to unify her fragmented self in a fifth notebook, the golden notebook. The novel explores themes of mental breakdown, communism, the changing role of women, and the fear of nuclear war.</Value>
+      <Value Culture="da"><![CDATA[En eksperimentel roman om en kvindelig forfatter, der bruger fem notesbøger til at udforsker forskellige aspekter af hendes liv. Værket er en feministisk meditation om kvinders oplevelser og indre liv.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel centers around a woman named Anna Wulf, a writer who keeps four notebooks, each representing a different aspect of her life: her experiences in Africa, her current life in London, a novel she is writing, and her personal experiences. As Anna's mental state deteriorates, she attempts to unify her fragmented self in a fifth notebook, the golden notebook. The novel explores themes of mental breakdown, communism, the changing role of women, and the fear of nuclear war.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-grapes-of-wrath.config
+++ b/src/_uSync/Shared/Content/the-grapes-of-wrath.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:41:45</CreateDate>
-    <NodeName>
+    <NodeName Default="The Grapes of Wrath">
       <Name Culture="da">Vreden</Name>
       <Name Culture="en-US">The Grapes of Wrath</Name>
     </NodeName>
     <SortOrder>19</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>John Steinbeck</Value>
+      <Value><![CDATA[John Steinbeck]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1939</Value>
+      <Value><![CDATA[1939]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En social realistisk roman om en famille af migrantarbejdere under den amerikanske depression. Fortællingen er en kraftfuld kritik af økonomisk undertrykkelse og en hyldest til menneskelig modstandskraft.</Value>
-      <Value Culture="en-US">The book follows the Joad family, Oklahoma farmers displaced from their land during the Great Depression. The family, alongside thousands of other "Okies," travel to California in search of work and a better life. Throughout their journey, they face numerous hardships and injustices, yet maintain their humanity through unity and shared sacrifice. The narrative explores themes of man's inhumanity to man, the dignity of wrath, and the power of family and friendship, offering a stark and moving portrayal of the harsh realities of American migrant laborers during the 1930s.</Value>
+      <Value Culture="da"><![CDATA[En social realistisk roman om en famille af migrantarbejdere under den amerikanske depression. Fortællingen er en kraftfuld kritik af økonomisk undertrykkelse og en hyldest til menneskelig modstandskraft.]]></Value>
+      <Value Culture="en-US"><![CDATA[The book follows the Joad family, Oklahoma farmers displaced from their land during the Great Depression. The family, alongside thousands of other "Okies," travel to California in search of work and a better life. Throughout their journey, they face numerous hardships and injustices, yet maintain their humanity through unity and shared sacrifice. The narrative explores themes of man's inhumanity to man, the dignity of wrath, and the power of family and friendship, offering a stark and moving portrayal of the harsh realities of American migrant laborers during the 1930s.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-great-gatsby.config
+++ b/src/_uSync/Shared/Content/the-great-gatsby.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:37:55</CreateDate>
-    <NodeName>
+    <NodeName Default="The Great Gatsby">
       <Name Culture="da">Den Store Gatsby</Name>
       <Name Culture="en-US">The Great Gatsby</Name>
     </NodeName>
     <SortOrder>2</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>F. Scott Fitzgerald</Value>
+      <Value><![CDATA[F. Scott Fitzgerald]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1925</Value>
+      <Value><![CDATA[1925]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En klassiker sat i Jazz Age'en, der følger en mystisk millionær's besatte kærlighed til en tidligere elskele. Romanen kritiserer det amerikanske drøm's tankeløshed og moralske tomhed.</Value>
-      <Value Culture="en-US">Set in the summer of 1922, the novel follows the life of a young and mysterious millionaire, his extravagant lifestyle in Long Island, and his obsessive love for a beautiful former debutante. As the story unfolds, the millionaire's dark secrets and the corrupt reality of the American dream during the Jazz Age are revealed. The narrative is a critique of the hedonistic excess and moral decay of the era, ultimately leading to tragic consequences.</Value>
+      <Value Culture="da"><![CDATA[En klassiker sat i Jazz Age'en, der følger en mystisk millionær's besatte kærlighed til en tidligere elskele. Romanen kritiserer det amerikanske drøm's tankeløshed og moralske tomhed.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in the summer of 1922, the novel follows the life of a young and mysterious millionaire, his extravagant lifestyle in Long Island, and his obsessive love for a beautiful former debutante. As the story unfolds, the millionaire's dark secrets and the corrupt reality of the American dream during the Jazz Age are revealed. The narrative is a critique of the hedonistic excess and moral decay of the era, ultimately leading to tragic consequences.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-leopard.config
+++ b/src/_uSync/Shared/Content/the-leopard.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:19:24</CreateDate>
-    <NodeName>
+    <NodeName Default="The Leopard">
       <Name Culture="da">Leoparden</Name>
       <Name Culture="en-US">The Leopard</Name>
     </NodeName>
     <SortOrder>45</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Giuseppe Tomasi di Lampedusa</Value>
+      <Value><![CDATA[Giuseppe Tomasi di Lampedusa]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "Italian"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1958</Value>
+      <Value><![CDATA[1958]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En italiensk klassiker om en aristocratisk families nedgang under Siciliens revolution. Fortællingen udforsker tema omkring tid, forandring og menneskets forsøg på at modstå forverring.</Value>
-      <Value Culture="en-US">"The Leopard" is a historical novel set in 19th-century Sicily, during the time of the Italian unification or Risorgimento. It centers on an aging, aristocratic protagonist who is coming to terms with the decline of his class and the rise of a new social order. The narrative weaves together personal drama with the larger political and social upheaval of the time, providing a rich, nuanced portrait of a society in transition. Despite his resistance to change, the protagonist ultimately recognizes its inevitability and the futility of his efforts to preserve the old ways.</Value>
+      <Value Culture="da"><![CDATA[En italiensk klassiker om en aristocratisk families nedgang under Siciliens revolution. Fortællingen udforsker tema omkring tid, forandring og menneskets forsøg på at modstå forverring.]]></Value>
+      <Value Culture="en-US"><![CDATA["The Leopard" is a historical novel set in 19th-century Sicily, during the time of the Italian unification or Risorgimento. It centers on an aging, aristocratic protagonist who is coming to terms with the decline of his class and the rise of a new social order. The narrative weaves together personal drama with the larger political and social upheaval of the time, providing a rich, nuanced portrait of a society in transition. Despite his resistance to change, the protagonist ultimately recognizes its inevitability and the futility of his efforts to preserve the old ways.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-life-and-opinions-of-tristram-shandy.config
+++ b/src/_uSync/Shared/Content/the-life-and-opinions-of-tristram-shandy.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:17:52</CreateDate>
-    <NodeName>
+    <NodeName Default="The Life And Opinions Of Tristram Shandy">
       <Name Culture="da">Tristram Shandys Liv og Meninger</Name>
       <Name Culture="en-US">The Life And Opinions Of Tristram Shandy</Name>
     </NodeName>
     <SortOrder>42</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Laurence Sterne</Value>
+      <Value><![CDATA[Laurence Sterne]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1759</Value>
+      <Value><![CDATA[1759]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En eksentrik 18. århundredes roman, der digre fra sit emne for at fortælle tilfælde og oplevelser fra fortiden. Værket er en lystigt chaotisk meditation på de menneskelige tilstande.</Value>
-      <Value Culture="en-US">The book is a humorous and digressive narrative that follows the eccentric life of Tristram Shandy, who recounts his own story in a non-linear fashion. It delves into the whimsical and often absurd experiences of his family and friends, blending satire, wit, and philosophical musings. The narrative frequently deviates into various anecdotes, reflections, and character studies, creating a rich tapestry of 18th-century life and thought. Through its unconventional structure and playful prose, the book challenges traditional storytelling conventions and explores the complexities of human nature and perception.</Value>
+      <Value Culture="da"><![CDATA[En eksentrik 18. århundredes roman, der digre fra sit emne for at fortælle tilfælde og oplevelser fra fortiden. Værket er en lystigt chaotisk meditation på de menneskelige tilstande.]]></Value>
+      <Value Culture="en-US"><![CDATA[The book is a humorous and digressive narrative that follows the eccentric life of Tristram Shandy, who recounts his own story in a non-linear fashion. It delves into the whimsical and often absurd experiences of his family and friends, blending satire, wit, and philosophical musings. The narrative frequently deviates into various anecdotes, reflections, and character studies, creating a rich tapestry of 18th-century life and thought. Through its unconventional structure and playful prose, the book challenges traditional storytelling conventions and explores the complexities of human nature and perception.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-little-prince.config
+++ b/src/_uSync/Shared/Content/the-little-prince.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T10:11:30</CreateDate>
-    <NodeName>
+    <NodeName Default="The Little Prince">
       <Name Culture="da">Den Lille Prins</Name>
       <Name Culture="en-US">The Little Prince</Name>
     </NodeName>
     <SortOrder>34</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Antoine de Saint-Exupéry</Value>
+      <Value><![CDATA[Antoine de Saint-Exupéry]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1943</Value>
+      <Value><![CDATA[1943]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En eventyrlig allegori om en ung prins fra en anden planet, der rejser rundt og møder forskellige karakterer. Bogen kombinerer børnefortælling med dybere filosofiske refleksioner over menneskelig natur.</Value>
-      <Value Culture="en-US">A young prince from a tiny asteroid embarks on a journey across the universe, visiting various planets and meeting their strange inhabitants. Along the way, he learns about the follies and absurdities of the adult world, the nature of friendship, and the importance of retaining a childlike wonder and curiosity. His journey eventually leads him to Earth, where he befriends a fox and learns about love and loss before finally returning to his asteroid.</Value>
+      <Value Culture="da"><![CDATA[En eventyrlig allegori om en ung prins fra en anden planet, der rejser rundt og møder forskellige karakterer. Bogen kombinerer børnefortælling med dybere filosofiske refleksioner over menneskelig natur.]]></Value>
+      <Value Culture="en-US"><![CDATA[A young prince from a tiny asteroid embarks on a journey across the universe, visiting various planets and meeting their strange inhabitants. Along the way, he learns about the follies and absurdities of the adult world, the nature of friendship, and the importance of retaining a childlike wonder and curiosity. His journey eventually leads him to Earth, where he befriends a fox and learns about love and loss before finally returning to his asteroid.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-magic-mountain.config
+++ b/src/_uSync/Shared/Content/the-magic-mountain.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:40:38</CreateDate>
-    <NodeName>
+    <NodeName Default="The Magic Mountain">
       <Name Culture="da">Det Magiske Bjerg</Name>
       <Name Culture="en-US">The Magic Mountain</Name>
     </NodeName>
     <SortOrder>17</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Thomas Mann</Value>
+      <Value><![CDATA[Thomas Mann]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "German"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1924</Value>
+      <Value><![CDATA[1924]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En kompleks roman om en ung mands ophold på et bjerg-sanatorium under 1. verdenskrig. Fortællingen udforsker tema omkring sygdom, tid, humanisme og politisk ideologi.</Value>
-      <Value Culture="en-US">In this novel, the protagonist, a young, ordinary man, visits his cousin at a tuberculosis sanatorium in the Swiss Alps. Intending to stay for only a few weeks, he ends up remaining there for seven years, becoming a patient himself. The book explores his experiences and relationships with other patients and staff, delving into philosophical discussions on life, time, and the nature of disease. It also provides a vivid portrayal of the European society and intellectual life on the eve of World War I.</Value>
+      <Value Culture="da"><![CDATA[En kompleks roman om en ung mands ophold på et bjerg-sanatorium under 1. verdenskrig. Fortællingen udforsker tema omkring sygdom, tid, humanisme og politisk ideologi.]]></Value>
+      <Value Culture="en-US"><![CDATA[In this novel, the protagonist, a young, ordinary man, visits his cousin at a tuberculosis sanatorium in the Swiss Alps. Intending to stay for only a few weeks, he ends up remaining there for seven years, becoming a patient himself. The book explores his experiences and relationships with other patients and staff, delving into philosophical discussions on life, time, and the nature of disease. It also provides a vivid portrayal of the European society and intellectual life on the eve of World War I.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-old-man-and-the-sea.config
+++ b/src/_uSync/Shared/Content/the-old-man-and-the-sea.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:17:24</CreateDate>
-    <NodeName>
+    <NodeName Default="The Old Man and the Sea">
       <Name Culture="da">Den Gamle Mand og Havet</Name>
       <Name Culture="en-US">The Old Man and the Sea</Name>
     </NodeName>
     <SortOrder>41</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Ernest Hemingway</Value>
+      <Value><![CDATA[Ernest Hemingway]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1952</Value>
+      <Value><![CDATA[1952]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En kort men dyb fortælling om en gammel fisker's episke kamp mod en gigantisk marlin på havet. Romanen udforsker menneskelig vedblivelse, håb og menneskets forhold til naturen.</Value>
-      <Value Culture="en-US">An aging Cuban fisherman struggles with a giant marlin far out in the Gulf Stream, isolated from the world and from human help. For days, he fights the marlin alone, admiring its strength, dignity, and faithfulness to its identity—its destiny is as true as his as a fisherman. He finally kills the marlin, but sharks attack and devour it before he can return to the shore. The fisherman returns home empty-handed but remains undefeated, having proven his abilities to himself.</Value>
+      <Value Culture="da"><![CDATA[En kort men dyb fortælling om en gammel fisker's episke kamp mod en gigantisk marlin på havet. Romanen udforsker menneskelig vedblivelse, håb og menneskets forhold til naturen.]]></Value>
+      <Value Culture="en-US"><![CDATA[An aging Cuban fisherman struggles with a giant marlin far out in the Gulf Stream, isolated from the world and from human help. For days, he fights the marlin alone, admiring its strength, dignity, and faithfulness to its identity—its destiny is as true as his as a fisherman. He finally kills the marlin, but sharks attack and devour it before he can return to the shore. The fisherman returns home empty-handed but remains undefeated, having proven his abilities to himself.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-red-and-the-black.config
+++ b/src/_uSync/Shared/Content/the-red-and-the-black.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:47:57</CreateDate>
-    <NodeName>
+    <NodeName Default="The Red and the Black">
       <Name Culture="da">Rød og Sort</Name>
       <Name Culture="en-US">The Red and the Black</Name>
     </NodeName>
     <SortOrder>30</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Stendhal</Value>
+      <Value><![CDATA[Stendhal]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1830</Value>
+      <Value><![CDATA[1830]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En 19. århundredes fransk roman om en ung ambitiøs mand, der søger at stige sosialt gennem sinuositet og manipulation. Fortællingen udforsker tema omkring ambition, kærlighed og klassespændinger.</Value>
-      <Value Culture="en-US">The novel is a detailed psychological portrait of Julien Sorel, a young man from a provincial background who aspires to rise above his humble beginnings. He uses his intelligence and hypocrisy to advance in the post-Napoleonic French society, which is deeply divided by class and political loyalties. The story is a critique of the society's materialism and hypocrisy as Julien's ambitions lead him to a tragic end. The title refers to the contrasting uniforms of the army and the church, the two routes available to him for upward mobility.</Value>
+      <Value Culture="da"><![CDATA[En 19. århundredes fransk roman om en ung ambitiøs mand, der søger at stige sosialt gennem sinuositet og manipulation. Fortællingen udforsker tema omkring ambition, kærlighed og klassespændinger.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel is a detailed psychological portrait of Julien Sorel, a young man from a provincial background who aspires to rise above his humble beginnings. He uses his intelligence and hypocrisy to advance in the post-Napoleonic French society, which is deeply divided by class and political loyalties. The story is a critique of the society's materialism and hypocrisy as Julien's ambitions lead him to a tragic end. The title refers to the contrasting uniforms of the army and the church, the two routes available to him for upward mobility.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-sound-and-the-fury.config
+++ b/src/_uSync/Shared/Content/the-sound-and-the-fury.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:42:54</CreateDate>
-    <NodeName>
+    <NodeName Default="The Sound and the Fury">
       <Name Culture="da">Lyden og Raseriets</Name>
       <Name Culture="en-US">The Sound and the Fury</Name>
     </NodeName>
     <SortOrder>9</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>William Faulkner</Value>
+      <Value><![CDATA[William Faulkner]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1929</Value>
+      <Value><![CDATA[1929]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En kompleks modernistisk roman, der udforsker en sydstatsfamilie's forverring gennem flere perspektiver og tidsrum. Værket er berømt for sin innovative fortælleteknik.</Value>
-      <Value Culture="en-US">The novel is a complex exploration of the tragic Compson family from the American South. Told from four distinct perspectives, the story unfolds through stream of consciousness narratives, each revealing their own understanding of the family's decline. The characters grapple with post-Civil War societal changes, personal loss, and their own mental instability. The narrative is marked by themes of time, innocence, and the burdens of the past.</Value>
+      <Value Culture="da"><![CDATA[En kompleks modernistisk roman, der udforsker en sydstatsfamilie's forverring gennem flere perspektiver og tidsrum. Værket er berømt for sin innovative fortælleteknik.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel is a complex exploration of the tragic Compson family from the American South. Told from four distinct perspectives, the story unfolds through stream of consciousness narratives, each revealing their own understanding of the family's decline. The characters grapple with post-Civil War societal changes, personal loss, and their own mental instability. The narrative is marked by themes of time, innocence, and the burdens of the past.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-stranger.config
+++ b/src/_uSync/Shared/Content/the-stranger.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:40:05</CreateDate>
-    <NodeName>
+    <NodeName Default="The Stranger">
       <Name Culture="da">Fremmeden</Name>
       <Name Culture="en-US">The Stranger</Name>
     </NodeName>
     <SortOrder>16</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Albert Camus</Value>
+      <Value><![CDATA[Albert Camus]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "French"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Very Short</Value>
+      <Value><![CDATA[Very Short]]></Value>
     </length>
     <publishYear>
-      <Value>1942</Value>
+      <Value><![CDATA[1942]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En eksistentialistisk roman om en mand, der mangler følelse og bliver dømt for mord. Fortællingen udforsker tema omkring absurditet, social tilpasning og menneskets isolation.</Value>
-      <Value Culture="en-US">Set in the sun-drenched landscapes of Algeria, this existential novel follows the life of an emotionally detached and indifferent man who becomes embroiled in a series of events leading to a senseless murder. Through his trial and eventual conviction, the narrative explores themes of absurdity, the meaning of life, and the societal expectations of morality. The protagonist's passive acceptance of his fate and his refusal to conform to conventional emotional responses challenge the reader to question the nature of existence and the human condition.</Value>
+      <Value Culture="da"><![CDATA[En eksistentialistisk roman om en mand, der mangler følelse og bliver dømt for mord. Fortællingen udforsker tema omkring absurditet, social tilpasning og menneskets isolation.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in the sun-drenched landscapes of Algeria, this existential novel follows the life of an emotionally detached and indifferent man who becomes embroiled in a series of events leading to a senseless murder. Through his trial and eventual conviction, the narrative explores themes of absurdity, the meaning of life, and the societal expectations of morality. The protagonist's passive acceptance of his fate and his refusal to conform to conventional emotional responses challenge the reader to question the nature of existence and the human condition.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-sun-also-rises.config
+++ b/src/_uSync/Shared/Content/the-sun-also-rises.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T14:20:20</CreateDate>
-    <NodeName>
+    <NodeName Default="The Sun Also Rises">
       <Name Culture="da">Solen Går også op</Name>
       <Name Culture="en-US">The Sun Also Rises</Name>
     </NodeName>
     <SortOrder>47</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Ernest Hemingway</Value>
+      <Value><![CDATA[Ernest Hemingway]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1926</Value>
+      <Value><![CDATA[1926]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En Lost Generation klassiker, der følger amerikanske og britiske expatriater i 1920erne, der rejser gennem Europa. Romanen skilder de skader fra 1. verdenskrig og søgningen efter mening.</Value>
-      <Value Culture="en-US">The novel is a poignant tale set in the 1920s post-World War I era, focusing on a group of American and British expatriates living in Paris who travel to Pamplona, Spain for the annual Running of the Bulls. The story explores themes of disillusionment, identity, and the Lost Generation, with the protagonist, a war veteran, grappling with impotence caused by a war injury. The narrative is steeped in the disillusionment and existential crisis experienced by many in the aftermath of the war, and the reckless hedonism of the era is portrayed through the characters' aimless wanderings and excessive drinking.</Value>
+      <Value Culture="da"><![CDATA[En Lost Generation klassiker, der følger amerikanske og britiske expatriater i 1920erne, der rejser gennem Europa. Romanen skilder de skader fra 1. verdenskrig og søgningen efter mening.]]></Value>
+      <Value Culture="en-US"><![CDATA[The novel is a poignant tale set in the 1920s post-World War I era, focusing on a group of American and British expatriates living in Paris who travel to Pamplona, Spain for the annual Running of the Bulls. The story explores themes of disillusionment, identity, and the Lost Generation, with the protagonist, a war veteran, grappling with impotence caused by a war injury. The narrative is steeped in the disillusionment and existential crisis experienced by many in the aftermath of the war, and the reckless hedonism of the era is portrayed through the characters' aimless wanderings and excessive drinking.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/the-trial.config
+++ b/src/_uSync/Shared/Content/the-trial.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:45:44</CreateDate>
-    <NodeName>
+    <NodeName Default="The Trial">
       <Name Culture="da">Retssagen</Name>
       <Name Culture="en-US">The Trial</Name>
     </NodeName>
     <SortOrder>14</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Franz Kafka</Value>
+      <Value><![CDATA[Franz Kafka]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "Czech"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1925</Value>
+      <Value><![CDATA[1925]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En surrealistisk roman om en mand, der bliver anklaget for en uspecificeret forbrydelse og undergår en kafkaisk retsprocedure. Fortællingen udforsker tema omkring skyld, magtmisbrug og menneskets hjælpeløshed.</Value>
-      <Value Culture="en-US">The book revolves around a bank clerk who wakes one morning to find himself under arrest for an unspecified crime. Despite not being detained, he is subjected to the psychological torment of a bizarre and nightmarish judicial process. The story is a critique of bureaucracy, exploring themes of guilt, alienation and the inefficiency of the justice system.</Value>
+      <Value Culture="da"><![CDATA[En surrealistisk roman om en mand, der bliver anklaget for en uspecificeret forbrydelse og undergår en kafkaisk retsprocedure. Fortællingen udforsker tema omkring skyld, magtmisbrug og menneskets hjælpeløshed.]]></Value>
+      <Value Culture="en-US"><![CDATA[The book revolves around a bank clerk who wakes one morning to find himself under arrest for an unspecified crime. Despite not being detained, he is subjected to the psychological torment of a bizarre and nightmarish judicial process. The story is a critique of bureaucracy, exploring themes of guilt, alienation and the inefficiency of the justice system.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/to-kill-a-mockingbird.config
+++ b/src/_uSync/Shared/Content/to-kill-a-mockingbird.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:44:48</CreateDate>
-    <NodeName>
+    <NodeName Default="To Kill a Mockingbird">
       <Name Culture="da">At Slå en Sangfugl ihjel</Name>
       <Name Culture="en-US">To Kill a Mockingbird</Name>
     </NodeName>
     <SortOrder>12</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Harper Lee</Value>
+      <Value><![CDATA[Harper Lee]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "American"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1960</Value>
+      <Value><![CDATA[1960]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En klassiker om et ungt piges opdagelse af injustice og racisme i det amerikanske syd. Fortællingen udforsker tema omkring moral, racisme og menneskets kapacitet til at handle med integritet.</Value>
-      <Value Culture="en-US">Set in the racially charged South during the Depression, the novel follows a young girl and her older brother as they navigate their small town's societal norms and prejudices. Their father, a lawyer, is appointed to defend a black man falsely accused of raping a white woman, forcing the children to confront the harsh realities of racism and injustice. The story explores themes of morality, innocence, and the loss of innocence through the eyes of the young protagonists.</Value>
+      <Value Culture="da"><![CDATA[En klassiker om et ungt piges opdagelse af injustice og racisme i det amerikanske syd. Fortællingen udforsker tema omkring moral, racisme og menneskets kapacitet til at handle med integritet.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in the racially charged South during the Depression, the novel follows a young girl and her older brother as they navigate their small town's societal norms and prejudices. Their father, a lawyer, is appointed to defend a black man falsely accused of raping a white woman, forcing the children to confront the harsh realities of racism and injustice. The story explores themes of morality, innocence, and the loss of innocence through the eyes of the young protagonists.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/to-the-lighthouse.config
+++ b/src/_uSync/Shared/Content/to-the-lighthouse.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-26T09:44:20</CreateDate>
-    <NodeName>
+    <NodeName Default="To the Lighthouse">
       <Name Culture="da">Til Fyret</Name>
       <Name Culture="en-US">To the Lighthouse</Name>
     </NodeName>
     <SortOrder>23</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Virginia Woolf</Value>
+      <Value><![CDATA[Virginia Woolf]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Short</Value>
+      <Value><![CDATA[Short]]></Value>
     </length>
     <publishYear>
-      <Value>1927</Value>
+      <Value><![CDATA[1927]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En modernistisk roman, der følger en familie's forsøg på at nå et fyr over tre dele. Værket er en meditation over tid, memory og menneskeligt forhold gennem stemningsfuldhed og indre tankestrøm.</Value>
-      <Value Culture="en-US">This novel is a pioneering work of modernist literature that explores the Ramsay family's experiences at their summer home on the Isle of Skye in Scotland. The narrative is divided into three sections, focusing on a day in the family's life, a description of the house during their absence, and their return after ten years. The book is known for its stream of consciousness narrative technique and its exploration of topics such as the passage of time, the nature of art, and the female experience.</Value>
+      <Value Culture="da"><![CDATA[En modernistisk roman, der følger en familie's forsøg på at nå et fyr over tre dele. Værket er en meditation over tid, memory og menneskeligt forhold gennem stemningsfuldhed og indre tankestrøm.]]></Value>
+      <Value Culture="en-US"><![CDATA[This novel is a pioneering work of modernist literature that explores the Ramsay family's experiences at their summer home on the Isle of Skye in Scotland. The narrative is divided into three sections, focusing on a day in the family's life, a description of the house during their absence, and their return after ten years. The book is known for its stream of consciousness narrative technique and its exploration of topics such as the passage of time, the nature of art, and the female experience.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/ulysses.config
+++ b/src/_uSync/Shared/Content/ulysses.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:36:29</CreateDate>
-    <NodeName>
+    <NodeName Default="Ulysses">
       <Name Culture="da">Odysseus</Name>
       <Name Culture="en-US">Ulysses</Name>
     </NodeName>
     <SortOrder>0</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>James Joyce</Value>
+      <Value><![CDATA[James Joyce]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "Irish"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Long</Value>
+      <Value><![CDATA[Long]]></Value>
     </length>
     <publishYear>
-      <Value>1922</Value>
+      <Value><![CDATA[1922]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En monumentalt modernistisk roman, der følger en mands ordinarje dag i Dublin gennem Joyce's avantgarde litterære stil. Fortællingen er fyldt med litterær eksperimentering og homageværk til klassik.</Value>
-      <Value Culture="en-US">Set in Dublin, the novel follows a day in the life of Leopold Bloom, an advertising salesman, as he navigates the city. The narrative, heavily influenced by Homer's Odyssey, explores themes of identity, heroism, and the complexities of everyday life. It is renowned for its stream-of-consciousness style and complex structure, making it a challenging but rewarding read.</Value>
+      <Value Culture="da"><![CDATA[En monumentalt modernistisk roman, der følger en mands ordinarje dag i Dublin gennem Joyce's avantgarde litterære stil. Fortællingen er fyldt med litterær eksperimentering og homageværk til klassik.]]></Value>
+      <Value Culture="en-US"><![CDATA[Set in Dublin, the novel follows a day in the life of Leopold Bloom, an advertising salesman, as he navigates the city. The narrative, heavily influenced by Homer's Odyssey, explores themes of identity, heroism, and the complexities of everyday life. It is renowned for its stream-of-consciousness style and complex structure, making it a challenging but rewarding read.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/Content/wuthering-heights.config
+++ b/src/_uSync/Shared/Content/wuthering-heights.config
@@ -6,12 +6,12 @@
     <Trashed>false</Trashed>
     <ContentType>book</ContentType>
     <CreateDate>2025-06-25T19:45:16</CreateDate>
-    <NodeName>
+    <NodeName Default="Wuthering Heights">
       <Name Culture="da">Stormfulde Højder</Name>
       <Name Culture="en-US">Wuthering Heights</Name>
     </NodeName>
     <SortOrder>13</SortOrder>
-    <Published>
+    <Published Default="true">
       <Published Culture="da">true</Published>
       <Published Culture="en-US">true</Published>
     </Published>
@@ -20,22 +20,22 @@
   </Info>
   <Properties>
     <author>
-      <Value>Emily Brontë</Value>
+      <Value><![CDATA[Emily Brontë]]></Value>
     </author>
     <authorNationality>
-      <Value>[
+      <Value><![CDATA[[
   "British"
-]</Value>
+]]]></Value>
     </authorNationality>
     <length>
-      <Value>Medium</Value>
+      <Value><![CDATA[Medium]]></Value>
     </length>
     <publishYear>
-      <Value>1847</Value>
+      <Value><![CDATA[1847]]></Value>
     </publishYear>
     <summary>
-      <Value Culture="da">En gothisk roman om intense lidenskab og revanche på de Yorkshire heaths. Fortællingen udforsker dybe følelser, social klasse og menneskelig grusomhed gennem generationers løfter.</Value>
-      <Value Culture="en-US">This classic novel is a tale of love, revenge and social class set in the Yorkshire moors. It revolves around the intense, complex relationship between Catherine Earnshaw and Heathcliff, an orphan adopted by Catherine's father. Despite their deep affection for each other, Catherine marries Edgar Linton, a wealthy neighbor, leading Heathcliff to seek revenge on the two families. The story unfolds over two generations, reflecting the consequences of their choices and the destructive power of obsessive love.</Value>
+      <Value Culture="da"><![CDATA[En gothisk roman om intense lidenskab og revanche på de Yorkshire heaths. Fortællingen udforsker dybe følelser, social klasse og menneskelig grusomhed gennem generationers løfter.]]></Value>
+      <Value Culture="en-US"><![CDATA[This classic novel is a tale of love, revenge and social class set in the Yorkshire moors. It revolves around the intense, complex relationship between Catherine Earnshaw and Heathcliff, an orphan adopted by Catherine's father. Despite their deep affection for each other, Catherine marries Edgar Linton, a wealthy neighbor, leading Heathcliff to seek revenge on the two families. The story unfolds over two generations, reflecting the consequences of their choices and the destructive power of obsessive love.]]></Value>
     </summary>
   </Properties>
 </Content>

--- a/src/_uSync/Shared/ContentTypes/book.config
+++ b/src/_uSync/Shared/ContentTypes/book.config
@@ -17,6 +17,7 @@
     <Compositions />
     <DefaultTemplate></DefaultTemplate>
     <AllowedTemplates />
+    <AllowedInLibrary>false</AllowedInLibrary>
   </Info>
   <Structure />
   <GenericProperties>

--- a/src/_uSync/Shared/ContentTypes/books.config
+++ b/src/_uSync/Shared/ContentTypes/books.config
@@ -19,6 +19,7 @@
     <AllowedTemplates>
       <Template Key="61936e36-3fdc-414f-b6cc-8177628294d2">books</Template>
     </AllowedTemplates>
+    <AllowedInLibrary>false</AllowedInLibrary>
   </Info>
   <Structure>
     <ContentType Key="3acd95a1-b9bd-4392-be67-0281dbbe125f" SortOrder="0">book</ContentType>

--- a/src/_uSync/Shared/usync.config
+++ b/src/_uSync/Shared/usync.config
@@ -1,2 +1,2 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<uSync version="17.0.2.0" format="10.7.0" />
+<uSync version="18.0.0.0" format="10.7.0" hmac="syi1UIF0XTT4/ha2q8n8nbDVVkNOHAe9VankxUpNt5o=" />


### PR DESCRIPTION
# Notes
- Switching to umbraco 18 caused some genuine problems, especially with the way our integration tests are set up, due to automatic migrations being moved to a background thread, this means that our old method of running the migration (EA, just forcing one through), no longer worked, as it would cause deadlocking. 
- Implement a new `WaitForPackageMigrationsAsync` that can be used instead, which instead waits for `RuntimeLevel.Run`.
- Fixed a bug in ´RebuildIndexesNotificationHandler.cs` too, as now when removing a property, it reports differently in 18 😁
- ⚠️ There is still a usync bug, which means cold booting the tests site does not work for now. You have to put in the database from 17 in the `umbraco/DATA` folder, or run the install on main, and then swap to `v18/dev`