### PR TITLE
Changed visibility of `PropertyValueHandlerCollection` and related code

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Extensions/PropertyValueHandlerCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/Extensions/PropertyValueHandlerCollectionExtensions.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Search.Core.PropertyValueHandlers.Collection;
 
 namespace Umbraco.Cms.Search.Core.Extensions;
 
-internal static class PropertyValueHandlerCollectionExtensions
+public static class PropertyValueHandlerCollectionExtensions
 {
     public static IPropertyValueHandler? GetPropertyValueHandler(this PropertyValueHandlerCollection collection, IPropertyType propertyType)
     {

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/Collection/PropertyValueHandlerCollection.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/Collection/PropertyValueHandlerCollection.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Cms.Search.Core.PropertyValueHandlers.Collection;
 
-internal sealed class PropertyValueHandlerCollection : BuilderCollectionBase<IPropertyValueHandler>
+public sealed class PropertyValueHandlerCollection : BuilderCollectionBase<IPropertyValueHandler>
 {
     public PropertyValueHandlerCollection(Func<IEnumerable<IPropertyValueHandler>> items)
         : base(items)

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/Collection/PropertyValueHandlerCollectionBuilder.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/Collection/PropertyValueHandlerCollectionBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Cms.Search.Core.PropertyValueHandlers.Collection;
 
-internal sealed class PropertyValueHandlerCollectionBuilder
+public sealed class PropertyValueHandlerCollectionBuilder
     : LazyCollectionBuilderBase<PropertyValueHandlerCollectionBuilder, PropertyValueHandlerCollection, IPropertyValueHandler>
 {
     protected override PropertyValueHandlerCollectionBuilder This => this;


### PR DESCRIPTION
As mentioned in #155, the `PropertyValueHandlerCollection` has its merits for consumers. 

This PR changes its visibility from `internal` to `public`, along with a few related bits of code required to use it.