### PR TITLE
Fix media list view crash when searching with empty culture

### DIFF
--- a/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
+++ b/src/Umbraco.Cms.Search.Provider.Examine/Services/Searcher.cs
@@ -110,7 +110,7 @@ public class Searcher : IExamineSearcher
         {
             IBooleanOperation searchQuery = index.Searcher
                 .CreateQuery()
-                .GroupedOr([Constants.SystemFields.Culture], culture is null ? [Constants.Variance.Invariant] : [culture, Constants.Variance.Invariant]);
+                .GroupedOr([Constants.SystemFields.Culture], string.IsNullOrEmpty(culture) ? [Constants.Variance.Invariant] : [culture, Constants.Variance.Invariant]);
 
             if (query is not null)
             {

--- a/src/Umbraco.Test.Search.Examine.Integration/Tests/EmptyCultureTests.cs
+++ b/src/Umbraco.Test.Search.Examine.Integration/Tests/EmptyCultureTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using Umbraco.Cms.Search.Core.Models.Searching;
+
+namespace Umbraco.Test.Search.Examine.Integration.Tests;
+
+// tests related to searching with an empty (rather than null) culture, as happens for the
+// invariant Media section list view in the backoffice
+public class EmptyCultureTests : SearcherTestBase
+{
+    [Test]
+    public async Task CanQueryInvariantDocumentsWithEmptyCulture()
+    {
+        SearchResult result = await SearchAsync(query: "single12", culture: string.Empty);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Total, Is.EqualTo(1));
+                Assert.That(result.Documents.First().Id, Is.EqualTo(DocumentIds[12]));
+            });
+    }
+}


### PR DESCRIPTION
The Media list view supplies an empty-string culture rather than null. 

CreateBaseQuery guarded the Sys_Culture clause with `culture is null`, so an empty culture produced the term array ["", "none"], which Lucene rejects with ArgumentException: 'fieldValue' cannot be null or empty.

Treat an empty culture the same as a missing one (invariant-only) via string.IsNullOrEmpty.