### PR TITLE
add more properties to DateTimeOffsetPropertyValueHandler

### DIFF
--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DateTimeOffsetPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DateTimeOffsetPropertyValueHandler.cs
@@ -30,7 +30,7 @@ internal sealed class DateTimeOffsetPropertyValueHandler : IPropertyValueHandler
         DateTimeOffset? dateTimeOffset = property.GetValue(culture, segment, published) switch
         {
             DateTime dateTime => _dateTimeOffsetConverter.ToDateTimeOffset(dateTime),
-            string jsonValue => ParseDateTimeDto(jsonValue),
+            string jsonValue => ParseDateTimeOffset(jsonValue),
             _ => null
         };
 
@@ -39,7 +39,7 @@ internal sealed class DateTimeOffsetPropertyValueHandler : IPropertyValueHandler
             : [];
     }
 
-    private DateTimeOffset? ParseDateTimeDto(string jsonValue)
+    private DateTimeOffset? ParseDateTimeOffset(string jsonValue)
     {
         try
         {

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DateTimeOffsetPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DateTimeOffsetPropertyValueHandler.cs
@@ -1,4 +1,6 @@
 ﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Search.Core.Helpers;
 using Umbraco.Cms.Search.Core.Models.Indexing;
 
@@ -7,16 +9,46 @@ namespace Umbraco.Cms.Search.Core.PropertyValueHandlers;
 internal sealed class DateTimeOffsetPropertyValueHandler : IPropertyValueHandler, ICorePropertyValueHandler
 {
     private readonly IDateTimeOffsetConverter _dateTimeOffsetConverter;
+    private readonly IJsonSerializer _jsonSerializer;
 
-    public DateTimeOffsetPropertyValueHandler(IDateTimeOffsetConverter dateTimeOffsetConverter)
-        => _dateTimeOffsetConverter = dateTimeOffsetConverter;
+    public DateTimeOffsetPropertyValueHandler(IDateTimeOffsetConverter dateTimeOffsetConverter, IJsonSerializer jsonSerializer)
+    {
+        _dateTimeOffsetConverter = dateTimeOffsetConverter;
+        _jsonSerializer = jsonSerializer;
+    }
 
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Cms.Core.Constants.PropertyEditors.Aliases.DateTime
-            or Cms.Core.Constants.PropertyEditors.Aliases.PlainDateTime;
+            or Cms.Core.Constants.PropertyEditors.Aliases.PlainDateTime
+            or Cms.Core.Constants.PropertyEditors.Aliases.DateOnly
+            or Cms.Core.Constants.PropertyEditors.Aliases.TimeOnly
+            or Cms.Core.Constants.PropertyEditors.Aliases.DateTimeWithTimeZone
+            or Cms.Core.Constants.PropertyEditors.Aliases.DateTimeUnspecified;
 
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
-        => property.GetValue(culture, segment, published) is DateTime dateTime
-            ? [new IndexField(property.Alias, new IndexValue { DateTimeOffsets = [_dateTimeOffsetConverter.ToDateTimeOffset(dateTime)] }, culture, segment)]
+    {
+        DateTimeOffset? dateTimeOffset = property.GetValue(culture, segment, published) switch
+        {
+            DateTime dateTime => _dateTimeOffsetConverter.ToDateTimeOffset(dateTime),
+            string jsonValue => ParseDateTimeDto(jsonValue),
+            _ => null
+        };
+
+        return dateTimeOffset is not null
+            ? [new IndexField(property.Alias, new IndexValue { DateTimeOffsets = [dateTimeOffset.Value] }, culture, segment)]
             : [];
+    }
+
+    private DateTimeOffset? ParseDateTimeDto(string jsonValue)
+    {
+        try
+        {
+            return _jsonSerializer.Deserialize<DateTimeValueConverterBase.DateTimeDto>(jsonValue)?.Date;
+        }
+        catch
+        {
+            // silently fail - this is an invalid property value, expect it to be reported elsewhere
+            return null;
+        }
+    }
 }

--- a/src/Umbraco.Test.Search.Integration/Tests/PropertyValueHandlerTestsBase.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/PropertyValueHandlerTestsBase.cs
@@ -22,6 +22,46 @@ public abstract class PropertyValueHandlerTestsBase : ContentTestBase
             .Build();
         await dataTypeService.CreateAsync(decimalDataType, Constants.Security.SuperUserKey);
 
+        DataType dateOnlyDataType = new DataTypeBuilder()
+            .WithId(0)
+            .WithDatabaseType(ValueStorageType.Nvarchar)
+            .WithName("Date only")
+            .AddEditor()
+            .WithAlias(Constants.PropertyEditors.Aliases.DateOnly)
+            .Done()
+            .Build();
+        await dataTypeService.CreateAsync(dateOnlyDataType, Constants.Security.SuperUserKey);
+
+        DataType timeOnlyDataType = new DataTypeBuilder()
+            .WithId(0)
+            .WithDatabaseType(ValueStorageType.Nvarchar)
+            .WithName("Time only")
+            .AddEditor()
+            .WithAlias(Constants.PropertyEditors.Aliases.TimeOnly)
+            .Done()
+            .Build();
+        await dataTypeService.CreateAsync(timeOnlyDataType, Constants.Security.SuperUserKey);
+
+        DataType dateTimeWithTimeZoneDataType = new DataTypeBuilder()
+            .WithId(0)
+            .WithDatabaseType(ValueStorageType.Nvarchar)
+            .WithName("Date/time with time zone")
+            .AddEditor()
+            .WithAlias(Constants.PropertyEditors.Aliases.DateTimeWithTimeZone)
+            .Done()
+            .Build();
+        await dataTypeService.CreateAsync(dateTimeWithTimeZoneDataType, Constants.Security.SuperUserKey);
+
+        DataType dateTimeUnspecifiedDataType = new DataTypeBuilder()
+            .WithId(0)
+            .WithDatabaseType(ValueStorageType.Nvarchar)
+            .WithName("Date/time unspecified")
+            .AddEditor()
+            .WithAlias(Constants.PropertyEditors.Aliases.DateTimeUnspecified)
+            .Done()
+            .Build();
+        await dataTypeService.CreateAsync(dateTimeUnspecifiedDataType, Constants.Security.SuperUserKey);
+
         DataType tagsAsCsvDataType = new DataTypeBuilder()
             .WithId(0)
             .WithDatabaseType(ValueStorageType.Nvarchar)
@@ -197,6 +237,26 @@ public abstract class PropertyValueHandlerTestsBase : ContentTestBase
             .WithAlias("dateAndTimeValue")
             .WithDataTypeId(Constants.DataTypes.DateTime)
             .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.DateTime)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("dateOnlyValue")
+            .WithDataTypeId(dateOnlyDataType.Id)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.DateOnly)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("timeOnlyValue")
+            .WithDataTypeId(timeOnlyDataType.Id)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TimeOnly)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("dateTimeWithTimeZoneValue")
+            .WithDataTypeId(dateTimeWithTimeZoneDataType.Id)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.DateTimeWithTimeZone)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("dateTimeUnspecifiedValue")
+            .WithDataTypeId(dateTimeUnspecifiedDataType.Id)
+            .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.DateTimeUnspecified)
             .Done()
             .AddPropertyType()
             .WithAlias("tagsAsJsonValue")

--- a/src/Umbraco.Test.Search.Integration/Tests/SimplePropertyValueHandlerTests.cs
+++ b/src/Umbraco.Test.Search.Integration/Tests/SimplePropertyValueHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Search.Core.PropertyValueHandlers;
 using Umbraco.Cms.Search.Core.PropertyValueHandlers.Collection;
@@ -28,6 +29,23 @@ public class SimplePropertyValueHandlerTests : PropertyValueHandlerTestsBase
                     decimalValue = 56.78m,
                     dateValue = new DateTime(2001, 02, 03),
                     dateAndTimeValue = new DateTime(2004, 05, 06, 07, 08, 09),
+                    dateOnlyValue = jsonSerializer.Serialize(new DateTimeValueConverterBase.DateTimeDto
+                    {
+                        Date = new DateTimeOffset(new DateOnly(2010, 03, 15), TimeOnly.MinValue, TimeSpan.Zero),
+                    }),
+                    timeOnlyValue = jsonSerializer.Serialize(new DateTimeValueConverterBase.DateTimeDto
+                    {
+                        Date = new DateTimeOffset(DateOnly.MinValue, new TimeOnly(13, 45, 30), TimeSpan.Zero),
+                    }),
+                    dateTimeWithTimeZoneValue = jsonSerializer.Serialize(new DateTimeValueConverterBase.DateTimeDto
+                    {
+                        Date = new DateTimeOffset(new DateOnly(2012, 07, 20), new TimeOnly(9, 15, 0), TimeSpan.FromHours(2)),
+                        TimeZone = "Europe/Copenhagen",
+                    }),
+                    dateTimeUnspecifiedValue = jsonSerializer.Serialize(new DateTimeValueConverterBase.DateTimeDto
+                    {
+                        Date = new DateTimeOffset(new DateOnly(2015, 11, 05), new TimeOnly(18, 30, 0), TimeSpan.Zero),
+                    }),
                     tagsAsJsonValue = "[\"One\",\"Two\",\"Three\"]",
                     tagsAsCsvValue = "Four,Five,Six",
                     multipleTextstringsValue = "First\nSecond\nThird",
@@ -86,6 +104,18 @@ public class SimplePropertyValueHandlerTests : PropertyValueHandlerTestsBase
 
             DateTimeOffset? dateAndTimeValue = document.Fields.FirstOrDefault(f => f.FieldName == "dateAndTimeValue")?.Value.DateTimeOffsets?.SingleOrDefault();
             Assert.That(dateAndTimeValue, Is.EqualTo(new DateTimeOffset(new DateOnly(2004, 05, 06), new TimeOnly(07, 08, 09), TimeSpan.Zero)));
+
+            DateTimeOffset? dateOnlyValue = document.Fields.FirstOrDefault(f => f.FieldName == "dateOnlyValue")?.Value.DateTimeOffsets?.SingleOrDefault();
+            Assert.That(dateOnlyValue, Is.EqualTo(new DateTimeOffset(new DateOnly(2010, 03, 15), TimeOnly.MinValue, TimeSpan.Zero)));
+
+            DateTimeOffset? timeOnlyValue = document.Fields.FirstOrDefault(f => f.FieldName == "timeOnlyValue")?.Value.DateTimeOffsets?.SingleOrDefault();
+            Assert.That(timeOnlyValue, Is.EqualTo(new DateTimeOffset(DateOnly.MinValue, new TimeOnly(13, 45, 30), TimeSpan.Zero)));
+
+            DateTimeOffset? dateTimeWithTimeZoneValue = document.Fields.FirstOrDefault(f => f.FieldName == "dateTimeWithTimeZoneValue")?.Value.DateTimeOffsets?.SingleOrDefault();
+            Assert.That(dateTimeWithTimeZoneValue, Is.EqualTo(new DateTimeOffset(new DateOnly(2012, 07, 20), new TimeOnly(9, 15, 0), TimeSpan.FromHours(2))));
+
+            DateTimeOffset? dateTimeUnspecifiedValue = document.Fields.FirstOrDefault(f => f.FieldName == "dateTimeUnspecifiedValue")?.Value.DateTimeOffsets?.SingleOrDefault();
+            Assert.That(dateTimeUnspecifiedValue, Is.EqualTo(new DateTimeOffset(new DateOnly(2015, 11, 05), new TimeOnly(18, 30, 0), TimeSpan.Zero)));
 
             var tagsAsJsonValue = document.Fields.FirstOrDefault(f => f.FieldName == "tagsAsJsonValue")?.Value.Keywords?.ToArray();
             CollectionAssert.AreEqual(tagsAsJsonValue, new [] {"One", "Two", "Three"});


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco.Cms.Search/issues/170

# Notes
- Some editors were not being indexed, because they weren't being handled yet.
- Adds some of the property missing editiors in the "CanHandle"