### PR TITLE
Improved context for property value handlers (closes #160)

### DIFF
--- a/src/Umbraco.Cms.Search.Core/Extensions/PropertyValueHandlerCollectionExtensions.cs
+++ b/src/Umbraco.Cms.Search.Core/Extensions/PropertyValueHandlerCollectionExtensions.cs
@@ -9,7 +9,7 @@ public static class PropertyValueHandlerCollectionExtensions
     public static IPropertyValueHandler? GetPropertyValueHandler(this PropertyValueHandlerCollection collection, IPropertyType propertyType)
     {
         IPropertyValueHandler[] applicableHandlers = collection
-            .Where(handler => handler.CanHandle(propertyType.PropertyEditorAlias))
+            .Where(handler => handler.CanHandle(propertyType))
             .ToArray();
 
         // always prioritize custom value handlers over the built-in ones

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/BlockEditorPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/BlockEditorPropertyValueHandler.cs
@@ -36,6 +36,9 @@ internal abstract class BlockEditorPropertyValueHandler : IPropertyValueHandler
 
     public abstract bool CanHandle(string propertyEditorAlias);
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public virtual IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         BlockValue? blockValue = ParsePropertyValue(property, culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/BooleanPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/BooleanPropertyValueHandler.cs
@@ -8,6 +8,9 @@ internal sealed class BooleanPropertyValueHandler : IPropertyValueHandler, ICore
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.Boolean;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var value = ParsePropertyValue(property, culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/ContentPickerPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/ContentPickerPropertyValueHandler.cs
@@ -11,6 +11,9 @@ internal sealed class ContentPickerPropertyValueHandler : IPropertyValueHandler,
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.ContentPicker;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         Guid? key = ParsePropertyValue(property, culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DateTimeOffsetPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DateTimeOffsetPropertyValueHandler.cs
@@ -25,6 +25,9 @@ internal sealed class DateTimeOffsetPropertyValueHandler : IPropertyValueHandler
             or Cms.Core.Constants.PropertyEditors.Aliases.DateTimeWithTimeZone
             or Cms.Core.Constants.PropertyEditors.Aliases.DateTimeUnspecified;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         DateTimeOffset? dateTimeOffset = property.GetValue(culture, segment, published) switch

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DecimalPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/DecimalPropertyValueHandler.cs
@@ -9,6 +9,9 @@ internal sealed class DecimalPropertyValueHandler : IPropertyValueHandler, ICore
         => propertyEditorAlias is Cms.Core.Constants.PropertyEditors.Aliases.Decimal
             or Cms.Core.Constants.PropertyEditors.Aliases.PlainDecimal;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
         => property.GetValue(culture, segment, published) is decimal decimalValue
             ? [new IndexField(property.Alias, new IndexValue { Decimals = [decimalValue] }, culture, segment)]

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/IPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/IPropertyValueHandler.cs
@@ -11,7 +11,15 @@ public interface IPropertyValueHandler : IDiscoverable
     /// </summary>
     /// <param name="propertyEditorAlias">The property editor alias of the property.</param>
     /// <returns>True if the property can be handled, false otherwise.</returns>
+    [Obsolete("Please implement the overload that accepts IPropertyType instead. Will be removed when Umbraco Search is included in Umbraco CMS.")]
     bool CanHandle(string propertyEditorAlias);
+
+    /// <summary>
+    /// Determines whether the property value handler can handle a concrete property.
+    /// </summary>
+    /// <param name="propertyType">The property type of the property.</param>
+    /// <returns>True if the property can be handled, false otherwise.</returns>
+    bool CanHandle(IPropertyType propertyType) => CanHandle(propertyType.PropertyEditorAlias);
 
     /// <summary>
     /// Parses index fields for a property.

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/IntegerPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/IntegerPropertyValueHandler.cs
@@ -9,6 +9,9 @@ internal sealed class IntegerPropertyValueHandler : IPropertyValueHandler, ICore
         => propertyEditorAlias is Cms.Core.Constants.PropertyEditors.Aliases.Integer
             or Cms.Core.Constants.PropertyEditors.Aliases.PlainInteger;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
         => property.GetValue(culture, segment, published) is int integerValue
             ? [new IndexField(property.Alias, new IndexValue { Integers = [integerValue] }, culture, segment)]

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/KeywordStringPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/KeywordStringPropertyValueHandler.cs
@@ -15,6 +15,9 @@ internal sealed class KeywordStringPropertyValueHandler : IPropertyValueHandler,
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Cms.Core.Constants.PropertyEditors.Aliases.DropDownListFlexible or Cms.Core.Constants.PropertyEditors.Aliases.RadioButtonList or Cms.Core.Constants.PropertyEditors.Aliases.CheckBoxList;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var value = property.GetValue(culture, segment, published) as string;

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/LabelPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/LabelPropertyValueHandler.cs
@@ -21,6 +21,9 @@ internal sealed class LabelPropertyValueHandler : IPropertyValueHandler, ICorePr
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.Label;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var value = property.GetValue(culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MarkdownPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MarkdownPropertyValueHandler.cs
@@ -14,6 +14,9 @@ internal sealed class MarkdownPropertyValueHandler : IPropertyValueHandler, ICor
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Cms.Core.Constants.PropertyEditors.Aliases.MarkdownEditor;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         if (property.GetValue(culture, segment, published) is not string markdown)

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultiNodeTreePickerPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultiNodeTreePickerPropertyValueHandler.cs
@@ -19,6 +19,9 @@ internal sealed class MultiNodeTreePickerPropertyValueHandler : IPropertyValueHa
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.MultiNodeTreePicker;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         MultiNodePickerConfiguration? configuration = _dataTypeConfigurationCache.GetConfigurationAs<MultiNodePickerConfiguration>(property.PropertyType.DataTypeKey);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultiUrlPickerPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultiUrlPickerPropertyValueHandler.cs
@@ -17,6 +17,9 @@ internal sealed class MultiUrlPickerPropertyValueHandler : IPropertyValueHandler
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.MultiUrlPicker;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var texts = ParsePropertyValue(property, culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultipleTextstringPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/MultipleTextstringPropertyValueHandler.cs
@@ -8,6 +8,9 @@ internal sealed class MultipleTextstringPropertyValueHandler : IPropertyValueHan
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.MultipleTextstring;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var values = ParsePropertyValue(property, culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/NoopPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/NoopPropertyValueHandler.cs
@@ -13,6 +13,9 @@ internal sealed class NoopPropertyValueHandler : IPropertyValueHandler, ICorePro
             or Cms.Core.Constants.PropertyEditors.Aliases.ImageCropper
             or Cms.Core.Constants.PropertyEditors.Aliases.UploadField;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
         => [];
 }

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/PlainStringPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/PlainStringPropertyValueHandler.cs
@@ -10,6 +10,9 @@ internal sealed class PlainStringPropertyValueHandler : IPropertyValueHandler, I
             or Cms.Core.Constants.PropertyEditors.Aliases.TextArea
             or Cms.Core.Constants.PropertyEditors.Aliases.PlainString;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
         => property.GetValue(culture, segment, published) is string stringValue
            && string.IsNullOrWhiteSpace(stringValue) is false

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/SliderPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/SliderPropertyValueHandler.cs
@@ -10,6 +10,9 @@ internal sealed class SliderPropertyValueHandler : IPropertyValueHandler, ICoreP
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.Slider;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var values = ParsePropertyValue(property, culture, segment, published);

--- a/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/TagsPropertyValueHandler.cs
+++ b/src/Umbraco.Cms.Search.Core/PropertyValueHandlers/TagsPropertyValueHandler.cs
@@ -22,6 +22,9 @@ internal sealed class TagsPropertyValueHandler : IPropertyValueHandler, ICorePro
     public bool CanHandle(string propertyEditorAlias)
         => propertyEditorAlias is Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.Tags;
 
+    public bool CanHandle(IPropertyType propertyType)
+        => CanHandle(propertyType.PropertyEditorAlias);
+
     public IEnumerable<IndexField> GetIndexFields(IProperty property, string? culture, string? segment, bool published, IContentBase contentContext)
     {
         var values = ParsePropertyValue(property, culture, segment, published);


### PR DESCRIPTION
Allows a property value handler to make decisions on whether it can handle a certain property based on the entire property type, not just the property editor alias.

This means a property value handler can now handle concrete/custom implementations that reuse the core property editors like `Umbraco.Plain.Json`.

See also [this comment](https://github.com/umbraco/Umbraco.Cms.Search/issues/160#issuecomment-4862443829) for additional background. 